### PR TITLE
Serialize GPU context disposal

### DIFF
--- a/PerfectNumbers.Core/Gpu/GpuContextPool.cs
+++ b/PerfectNumbers.Core/Gpu/GpuContextPool.cs
@@ -114,11 +114,14 @@ public static class GpuContextPool
 			}
 		}
 
-		else
-		{
-			ctx.Dispose();
-		}
-	}
+                else
+                {
+                        lock (CreationLock)
+                        {
+                                ctx.Dispose();
+                        }
+                }
+        }
 
     public struct GpuContextLease : IDisposable
     {


### PR DESCRIPTION
## Summary
- serialize GPU context destruction to avoid OpenCL context release crashes when pooling is disabled

## Testing
- `dotnet build EvenPerfectScanner.sln -c Release`
- `dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Release --filter "FullyQualifiedName~GpuContextPoolTests"` *(fails: PerfectNumbers.Core.Tests.Gpu.GpuContextPoolTests.RentPreferred_reuses_cpu_context)*


------
https://chatgpt.com/codex/tasks/task_e_68c07e0c3a1c8325b1bc19bb14cb3551