### PR TITLE
Fix borrow handling in GpuUInt128 subtraction

### DIFF
--- a/PerfectNumbers.Core/Gpu/GpuUInt128.cs
+++ b/PerfectNumbers.Core/Gpu/GpuUInt128.cs
@@ -246,7 +246,7 @@ public readonly struct GpuUInt128 : IComparable<GpuUInt128>, IEquatable<GpuUInt1
     public GpuUInt128 Sub(GpuUInt128 other)
     {
         ulong borrow = Low < other.Low ? 1UL : 0UL;
-        return new(High - other.High + borrow, Low - other.Low);
+        return new(High - other.High - borrow, Low - other.Low);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Summary
- correct borrow computation in GpuUInt128 subtraction

## Testing
- `timeout 120s dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj --filter "FullyQualifiedName~GpuUInt128Tests"`


------
https://chatgpt.com/codex/tasks/task_e_68c08be2b9608325858947f07bd9932f