### PR TITLE
Implement UInt128 exponentiation and apply in Mersenne scan

### DIFF
--- a/PerfectNumbers.Core.Tests/UInt128Extensions/UInt128ExtensionsTests.cs
+++ b/PerfectNumbers.Core.Tests/UInt128Extensions/UInt128ExtensionsTests.cs
@@ -114,6 +114,40 @@ public class UInt128ExtensionsTests
 
     [Theory]
     [Trait("Category", "Fast")]
+    [InlineData(2UL, 0UL)]
+    [InlineData(2UL, 1UL)]
+    [InlineData(2UL, 63UL)]
+    [InlineData(2UL, 127UL)]
+    [InlineData(3UL, 5UL)]
+    public void Pow_matches_BigInteger(ulong value, ulong exponent)
+    {
+        UInt128 v = value;
+        UInt128 expected = (UInt128)BigPow(value, exponent);
+
+        v.Pow(exponent).Should().Be(expected);
+    }
+
+    private static BigInteger BigPow(ulong value, ulong exponent)
+    {
+        BigInteger result = BigInteger.One;
+        BigInteger baseValue = value;
+
+        while (exponent != 0UL)
+        {
+            if ((exponent & 1UL) != 0UL)
+            {
+                result *= baseValue;
+            }
+
+            baseValue *= baseValue;
+            exponent >>= 1;
+        }
+
+        return result;
+    }
+
+    [Theory]
+    [Trait("Category", "Fast")]
     [InlineData(2UL, 10UL, 17UL)]
     [InlineData(123456789UL, 3UL, 97UL)]
     public void ModPow_matches_BigInteger(ulong value, ulong exponent, ulong modulus)

--- a/PerfectNumbers.Core/MersenneNumberTester.cs
+++ b/PerfectNumbers.Core/MersenneNumberTester.cs
@@ -214,7 +214,7 @@ public sealed class MersenneNumberTester(
 		bool prePrime = true;
         UInt128 twoP = (UInt128)exponent << 1; // 2 * p
         // UInt128 maxDivisor = new(ulong.MaxValue, ulong.MaxValue);
-        UInt128 maxK = (UInt128Numbers.Two ^ exponent) / 2 + 1;
+        UInt128 maxK = UInt128Numbers.Two.Pow(exponent) / 2 + 1;
         bool lastIsSeven = (exponent & 3UL) == 3UL;
 
 		// This is how maxK was for residue test before changes UInt128 maxK = maxKOverride ?? ResidueMaxK;

--- a/PerfectNumbers.Core/UInt128Extensions.cs
+++ b/PerfectNumbers.Core/UInt128Extensions.cs
@@ -150,15 +150,35 @@ public static class UInt128Extensions
 			high >>= 64;
 		}
 
-		mod10 = result % 10UL;
-	}
+                mod10 = result % 10UL;
+        }
 
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static UInt128 ModPow(this UInt128 value, UInt128 exponent, UInt128 modulus)
-	{
-		UInt128 result, one = result = UInt128.One,
-				zero = UInt128.Zero,
-				baseValue = value % modulus;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static UInt128 Pow(this UInt128 value, ulong exponent)
+        {
+                UInt128 result = UInt128.One;
+                UInt128 baseValue = value;
+
+                while (exponent != 0UL)
+                {
+                        if ((exponent & 1UL) != 0UL)
+                        {
+                                result *= baseValue;
+                        }
+
+                        baseValue *= baseValue;
+                        exponent >>= 1;
+                }
+
+                return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static UInt128 ModPow(this UInt128 value, UInt128 exponent, UInt128 modulus)
+        {
+                UInt128 result, one = result = UInt128.One,
+                                zero = UInt128.Zero,
+                                baseValue = value % modulus;
 
 		while (exponent != zero)
 		{


### PR DESCRIPTION
## Summary
- add Pow extension to compute UInt128 raised to a ulong power
- use new Pow when calculating maxK in MersenneNumberTester
- cover Pow with unit tests

## Testing
- `dotnet build EvenPerfectScanner.sln`
- `dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter FullyQualifiedName~UInt128ExtensionsTests`
- `dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName=PerfectNumbers.Core.Tests.MersenneResidueModeTests.IsMersennePrime_residue_mode_rejects_composite_exponent"`


------
https://chatgpt.com/codex/tasks/task_e_68c0b5e3a0348325a6de253cb8849ffd