### PR TITLE
Ensure GPU buffers are disposed safely

### DIFF
--- a/PerfectNumbers.Core/Gpu/MersenneNumberResidueGpuTester.cs
+++ b/PerfectNumbers.Core/Gpu/MersenneNumberResidueGpuTester.cs
@@ -74,14 +74,13 @@ public class MersenneNumberResidueGpuTester(bool useGpuOrder)
 
                                 kStart += batchSize128;
                         }
-                }
-                finally
-                {
-                        ArrayPool<ulong>.Shared.Return(orderArray);
-                }
-
+        }
+        finally
+        {
+                ArrayPool<ulong>.Shared.Return(orderArray);
                 orderBuffer.Dispose();
                 gpuLease.Dispose();
+        }
 
     }
 }


### PR DESCRIPTION
## Summary
- prevent OpenCL access violations by disposing GPU buffers and kernel leases in a finally block

## Testing
- `timeout 120s dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Release --filter "FullyQualifiedName~MersenneNumberResidueGpuTesterTests"`


------
https://chatgpt.com/codex/tasks/task_e_68c0cfa720f88325b259e0601ffe3e9d