### PR TITLE
Add batch Lucas-Lehmer GPU residue computation

### DIFF
--- a/PerfectNumbers.Core.Tests/Gpu/LucasLehmerPrimeTesterTests.cs
+++ b/PerfectNumbers.Core.Tests/Gpu/LucasLehmerPrimeTesterTests.cs
@@ -29,6 +29,18 @@ public class LucasLehmerPrimeTesterTests
         tester.IsMersennePrime(exponent).Should().BeFalse();
     }
 
+    [Fact]
+    [Trait("Category", "Fast")]
+    public void IsMersennePrimeBatch_matches_individual()
+    {
+        ulong[] exponents = new ulong[] { 3UL, 5UL, 7UL, 11UL, 13UL, 17UL, 19UL, 23UL };
+        bool[] expected = new bool[] { true, true, true, false, true, true, true, false };
+        var tester = new MersenneNumberLucasLehmerGpuTester();
+        bool[] results = new bool[exponents.Length];
+        tester.IsMersennePrimeBatch(exponents, results);
+        results.Should().Equal(expected);
+    }
+
     [Theory]
     [InlineData(132UL)]
     [InlineData(1000UL)]


### PR DESCRIPTION
## Summary
- support computing Lucas-Lehmer residues for up to eight exponents in parallel on the GPU
- expose batch APIs for residue and primality checks
- cover batch Lucas-Lehmer execution with unit tests

## Testing
- `dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName~LucasLehmerPrimeTesterTests&Category=Fast"` *(fails: execution cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a4e0e9548325a13a65ee0b79823b