### PR TITLE
Scan divisor cycles beyond precomputed limit

### DIFF
--- a/EvenPerfectBitScanner.Tests/ProgramTests.cs
+++ b/EvenPerfectBitScanner.Tests/ProgramTests.cs
@@ -68,7 +68,7 @@ public class ProgramTests
     }
 
     [Fact]
-    public void Divisor_mode_checks_all_candidates_when_none_specified()
+    public void Divisor_mode_scans_dynamic_cycles_when_none_specified()
     {
         var useDivisorField = typeof(Program).GetField("_useDivisor", BindingFlags.NonPublic | BindingFlags.Static)!;
         var divisorField = typeof(Program).GetField("_divisor", BindingFlags.NonPublic | BindingFlags.Static)!;
@@ -80,7 +80,7 @@ public class ProgramTests
 
         useDivisorField.SetValue(null, true);
         divisorField.SetValue(null, 0UL);
-        testerField.SetValue(null, new MersenneNumberDivisorGpuTester());
+        testerField.SetValue(null, null);
         primeField.SetValue(null, new ThreadLocal<PrimeTester>(() => new PrimeTester(), trackAllValues: true));
         residueField.SetValue(null, new ThreadLocal<ModResidueTracker>(() => new ModResidueTracker(ResidueModel.Identity, 2UL, true), trackAllValues: true));
         candidatesField.SetValue(null, new (ulong, uint)[] { (7UL, 3U), (23UL, 11U) });
@@ -88,8 +88,8 @@ public class ProgramTests
 
         try
         {
-            Program.IsEvenPerfectCandidate(11UL).Should().BeTrue();
-            Program.IsEvenPerfectCandidate(5UL).Should().BeFalse();
+            Program.IsEvenPerfectCandidate(11UL).Should().BeFalse();
+            Program.IsEvenPerfectCandidate(5UL).Should().BeTrue();
         }
         finally
         {


### PR DESCRIPTION
## Summary
- explore extra divisor cycles derived from 2·k·p + 1 when scanning candidates
- handle divisibility checks through a shared helper with a simple fallback
- update divisor-mode test to cover dynamic cycle discovery
- treat divisor-mode candidates as perfect by default and mark them composite only when a factor is found

## Testing
- `dotnet build EvenPerfectScanner.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c1f8f5ac3c832584fca665de2c79e6