### PR TITLE
Ensure GPU residue copy completes before buffer disposal

### DIFF
--- a/PerfectNumbers.Core/Gpu/MersenneNumberResidueGpuTester.cs
+++ b/PerfectNumbers.Core/Gpu/MersenneNumberResidueGpuTester.cs
@@ -58,6 +58,7 @@ public class MersenneNumberResidueGpuTester(bool useGpuOrder)
 
                                 accelerator.Synchronize();
                                 orderBuffer.View.CopyToCPU(ref MemoryMarshal.GetReference(orders), currentSize);
+                                accelerator.Synchronize();
                                 if (!Volatile.Read(ref isPrime))
                                 {
                                         break;


### PR DESCRIPTION
## Summary
- synchronize after copying GPU residues to the host to prevent releasing device buffers while transfers are in flight

## Testing
- `timeout 120s dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName=PerfectNumbers.Core.Tests.MersenneNumberResidueGpuTesterTests.Scan_handles_various_prime_exponents"`


------
https://chatgpt.com/codex/tasks/task_e_68c211f9a0208325b38de96764e042b3