### PR TITLE
Switch GpuUInt128 back to mutable form

### DIFF
--- a/PerfectNumbers.Core.Tests/Gpu/GpuUInt128Pow2Minus1ModTests.cs
+++ b/PerfectNumbers.Core.Tests/Gpu/GpuUInt128Pow2Minus1ModTests.cs
@@ -13,7 +13,17 @@ public class GpuUInt128Pow2Minus1ModTests
         ulong exponent = 23UL;
         GpuUInt128 modulus = new(0UL, 97UL);
         var pow = GpuUInt128.Pow2Mod(exponent, modulus);
-        var expected = pow.IsZero ? modulus.Sub(GpuUInt128.One) : pow.Sub(GpuUInt128.One);
+        GpuUInt128 expected;
+        if (pow.IsZero)
+        {
+            expected = modulus;
+            expected.Sub(GpuUInt128.One);
+        }
+        else
+        {
+            expected = pow;
+            expected.Sub(GpuUInt128.One);
+        }
         var actual = GpuUInt128.Pow2Minus1Mod(exponent, modulus);
         actual.Should().Be(expected);
     }

--- a/PerfectNumbers.Core.Tests/Gpu/GpuUInt128Tests.cs
+++ b/PerfectNumbers.Core.Tests/Gpu/GpuUInt128Tests.cs
@@ -18,7 +18,7 @@ public class GpuUInt128Tests
             var a = new GpuUInt128(high1, low1);
             var b = new GpuUInt128(high2, low2);
             var expected = (UInt128)new GpuUInt128(high1, low1) * (UInt128)new GpuUInt128(high2, low2);
-            a = a.Mul(b);
+            a.Mul(b);
             ((UInt128)a).Should().Be(expected);
         }
     }
@@ -39,7 +39,7 @@ public class GpuUInt128Tests
             var a = new GpuUInt128((UInt128)new GpuUInt128(high1, low1) % (UInt128)modulus);
             var b = new GpuUInt128((UInt128)new GpuUInt128(high2, low2) % (UInt128)modulus);
             var expected = MulModReference((UInt128)a, (UInt128)b, (UInt128)modulus);
-            a = a.MulMod(b, modulus);
+            a.MulMod(b, modulus);
             ((UInt128)a).Should().Be(expected);
         }
     }
@@ -60,7 +60,7 @@ public class GpuUInt128Tests
             UInt128 bBig = (UInt128)bRaw % (UInt128)modulus;
             ulong b = (ulong)bBig;
             var expected = MulModReference((UInt128)a, bBig, (UInt128)modulus);
-            a = a.MulMod(b, modulus);
+            a.MulMod(b, modulus);
             ((UInt128)a).Should().Be(expected);
         }
     }
@@ -79,7 +79,7 @@ public class GpuUInt128Tests
             var a = new GpuUInt128(aVal);
             var b = new GpuUInt128(bVal);
             UInt128 expected = ((UInt128)aVal * bVal) % modulus;
-            a = a.MulMod(b, modulus);
+            a.MulMod(b, modulus);
             ((UInt128)a).Should().Be(expected);
         }
     }
@@ -101,7 +101,7 @@ public class GpuUInt128Tests
             var b = new GpuUInt128((UInt128)new GpuUInt128(high2, low2) % (UInt128)modulus);
             var expected = MulModReference((UInt128)a, (UInt128)b, (UInt128)modulus);
             var result = new GpuUInt128(a.High, a.Low);
-            result = result.MulModBigInteger(b, modulus);
+            result.MulModBigInteger(b, modulus);
             ((UInt128)result).Should().Be(expected);
         }
     }
@@ -119,7 +119,7 @@ public class GpuUInt128Tests
             var modulus = new GpuUInt128(modHigh, modLow);
             var a = new GpuUInt128((UInt128)new GpuUInt128(valueHigh, valueLow) % (UInt128)modulus);
             var expected = MulModReference((UInt128)a, (UInt128)a, (UInt128)modulus);
-            a = a.SquareMod(modulus);
+            a.SquareMod(modulus);
             ((UInt128)a).Should().Be(expected);
         }
     }
@@ -142,7 +142,7 @@ public class GpuUInt128Tests
             var exponent = new GpuUInt128(expHigh, expLow);
 
             var expected = (UInt128)System.Numerics.BigInteger.ModPow((System.Numerics.BigInteger)(UInt128)value, (System.Numerics.BigInteger)(UInt128)exponent, (System.Numerics.BigInteger)(UInt128)modulus);
-            value = value.ModPow(exponent, modulus);
+            value.ModPow(exponent, modulus);
             ((UInt128)value).Should().Be(expected);
         }
     }
@@ -163,7 +163,7 @@ public class GpuUInt128Tests
             var value = new GpuUInt128((UInt128)new GpuUInt128(baseHigh, baseLow) % (UInt128)modulus);
 
             var expected = (UInt128)System.Numerics.BigInteger.ModPow((System.Numerics.BigInteger)(UInt128)value, exponent, (System.Numerics.BigInteger)(UInt128)modulus);
-            value = value.ModPow(exponent, modulus);
+            value.ModPow(exponent, modulus);
             ((UInt128)value).Should().Be(expected);
         }
     }
@@ -184,7 +184,7 @@ public class GpuUInt128Tests
             var a = new GpuUInt128((UInt128)new GpuUInt128(valueHigh, valueLow) % (UInt128)modulus);
             var b = new GpuUInt128((UInt128)new GpuUInt128(subHigh, subLow) % (UInt128)modulus);
             UInt128 expected = ((UInt128)a + (UInt128)modulus - (UInt128)b) % (UInt128)modulus;
-            a = a.SubMod(b, modulus);
+            a.SubMod(b, modulus);
             ((UInt128)a).Should().Be(expected);
         }
     }
@@ -205,7 +205,7 @@ public class GpuUInt128Tests
             UInt128 bBig = (UInt128)subRaw % (UInt128)modulus;
             ulong b = (ulong)bBig;
             UInt128 expected = ((UInt128)a + (UInt128)modulus - bBig) % (UInt128)modulus;
-            a = a.SubMod(b, modulus);
+            a.SubMod(b, modulus);
             ((UInt128)a).Should().Be(expected);
         }
     }
@@ -226,7 +226,7 @@ public class GpuUInt128Tests
             var a = new GpuUInt128((UInt128)new GpuUInt128(valueHigh, valueLow) % (UInt128)modulus);
             var b = new GpuUInt128((UInt128)new GpuUInt128(addHigh, addLow) % (UInt128)modulus);
             UInt128 expected = ((UInt128)a + (UInt128)b) % (UInt128)modulus;
-            a = a.AddMod(b, modulus);
+            a.AddMod(b, modulus);
             ((UInt128)a).Should().Be(expected);
         }
     }
@@ -245,7 +245,7 @@ public class GpuUInt128Tests
             var a = new GpuUInt128(aVal);
             var b = new GpuUInt128(bVal);
             UInt128 expected = ((UInt128)aVal + bVal) % modulus;
-            a = a.AddMod(b, modulus);
+            a.AddMod(b, modulus);
             ((UInt128)a).Should().Be(expected);
         }
     }
@@ -263,7 +263,7 @@ public class GpuUInt128Tests
             ulong bVal = bRaw % modulus;
             var a = new GpuUInt128(aVal);
             UInt128 expected = ((UInt128)aVal + bVal) % modulus;
-            a = a.AddMod(bVal, modulus);
+            a.AddMod(bVal, modulus);
             ((UInt128)a).Should().Be(expected);
         }
     }
@@ -282,11 +282,11 @@ public class GpuUInt128Tests
             var value = new GpuUInt128((UInt128)new GpuUInt128(valueHigh, valueLow) % (UInt128)modulus);
             if (value.IsZero)
             {
-                value = value.Add(1UL);
+                value.Add(1UL);
             }
 
             var expected = (UInt128)System.Numerics.BigInteger.ModPow((System.Numerics.BigInteger)(UInt128)value, (System.Numerics.BigInteger)(UInt128)modulus - 2, (System.Numerics.BigInteger)(UInt128)modulus);
-            value = value.ModInv(modulus);
+            value.ModInv(modulus);
             ((UInt128)value).Should().Be(expected);
         }
     }
@@ -302,11 +302,11 @@ public class GpuUInt128Tests
             var value = new GpuUInt128((UInt128)(raw % modulus));
             if (value.IsZero)
             {
-                value = value.Add(1UL);
+                value.Add(1UL);
             }
 
             var expected = (UInt128)System.Numerics.BigInteger.ModPow((System.Numerics.BigInteger)(UInt128)value, (System.Numerics.BigInteger)modulus - 2, (System.Numerics.BigInteger)modulus);
-            value = value.ModInv(modulus);
+            value.ModInv(modulus);
             ((UInt128)value).Should().Be(expected);
         }
     }

--- a/PerfectNumbers.Core/Gpu/MersenneNumberDivisorGpuTester.cs
+++ b/PerfectNumbers.Core/Gpu/MersenneNumberDivisorGpuTester.cs
@@ -48,10 +48,11 @@ public sealed class MersenneNumberDivisorGpuTester
 		ulong pow2x = 1UL << x;
 		ulong y = divisor - pow2x;
 		var modVal = new GpuUInt128(0UL, divisor);
-		var baseVal = new GpuUInt128(0UL, pow2x); // 2^x ≡ -y (mod divisor)
-		var part1 = baseVal.ModPow(q, modVal);
-		var part2 = GpuUInt128.Pow2Mod(r, modVal);
-		var rem = part1.MulMod(part2, modVal);
-		result[0] = rem.High == 0UL && rem.Low == 1UL ? (byte)1 : (byte)0;
+                var baseVal = new GpuUInt128(0UL, pow2x); // 2^x ≡ -y (mod divisor)
+                var part1 = baseVal;
+                part1.ModPow(q, modVal);
+                var part2 = GpuUInt128.Pow2Mod(r, modVal);
+                part1.MulMod(part2, modVal);
+                result[0] = part1.High == 0UL && part1.Low == 1UL ? (byte)1 : (byte)0;
 	}
 }

--- a/PerfectNumbers.Core/Gpu/MersenneNumberLucasLehmerGpuTester.cs
+++ b/PerfectNumbers.Core/Gpu/MersenneNumberLucasLehmerGpuTester.cs
@@ -526,7 +526,7 @@ public class MersenneNumberLucasLehmerGpuTester
             int target = i - limbCount;
             var sum = value[target];
             var original = sum;
-            sum = sum.Add(limb);
+            sum.Add(limb);
             value[target] = sum;
             value[i] = new GpuUInt128(0UL, 0UL);
             if (sum.CompareTo(original) < 0)
@@ -536,7 +536,7 @@ public class MersenneNumberLucasLehmerGpuTester
                 {
                     var next = value[j];
                     var nextOriginal = next;
-                    next = next.Add(1UL);
+                    next.Add(1UL);
                     value[j] = next;
                     if (next.CompareTo(nextOriginal) >= 0)
                     {
@@ -569,7 +569,7 @@ public class MersenneNumberLucasLehmerGpuTester
             {
                 var cur = value[j];
                 var curOriginal = cur;
-                cur = cur.Add(carryBits);
+                cur.Add(carryBits);
                 value[j] = cur;
                 carryBits = cur.CompareTo(curOriginal) < 0 ? new GpuUInt128(0UL, 1UL) : new GpuUInt128(0UL, 0UL);
                 j++;
@@ -756,7 +756,8 @@ public class MersenneNumberLucasLehmerGpuTester
         ulong limit = exponent - 2UL;
         for (ulong i = 0UL; i < limit; i++)
         {
-            s = SquareModMersenne128(s, exponent).SubMod(2UL, modulus);
+            s = SquareModMersenne128(s, exponent);
+            s.SubMod(2UL, modulus);
         }
 
         states[idx] = s;
@@ -773,14 +774,16 @@ public class MersenneNumberLucasLehmerGpuTester
         {
             for (; i < limit; i++)
             {
-                s = SquareModMersenne128(s, exponent).SubMod(2UL, modulus);
+                s = SquareModMersenne128(s, exponent);
+                s.SubMod(2UL, modulus);
             }
         }
         else
         {
             for (; i < limit; i++)
             {
-                s = s.SquareMod(modulus).SubMod(2UL, modulus);
+                s.SquareMod(modulus);
+                s.SubMod(2UL, modulus);
             }
         }
 
@@ -797,7 +800,7 @@ public class MersenneNumberLucasLehmerGpuTester
         // v = low128 + high128 (fold by 128 bits once)
         var vHigh = new GpuUInt128(q3, q2);
         var vLow = new GpuUInt128(q1, q0);
-        vLow = vLow.Add(vHigh);
+        vLow.Add(vHigh);
 
         // Mask to keep only p low bits and fold the carry bits (v >> p)
         int topBits = (int)(p % 128UL);
@@ -817,7 +820,7 @@ public class MersenneNumberLucasLehmerGpuTester
         while (!carryBits.IsZero)
 		{
 			before = vLow;
-			vLow = vLow.Add(carryBits);
+                    vLow.Add(carryBits);
 			carryBits = vLow.CompareTo(before) < 0 ? GpuUInt128.One : GpuUInt128.Zero;
 		}
 


### PR DESCRIPTION
## Summary
- make `GpuUInt128` mutable again and update its arithmetic methods to work in-place
- adjust GPU utilities and tests for new `GpuUInt128` semantics

## Testing
- `dotnet build EvenPerfectScanner.sln`
- `dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName~GpuUInt128"`


------
https://chatgpt.com/codex/tasks/task_e_68c21b739ef08325a6b9c5d9e22ab83f