### PR TITLE
Fix GPU divisor cycle generation indexing and add regression tests

### DIFF
--- a/PerfectNumbers.Core.Tests/MersenneDivisorCyclesGenerateGpuTests.cs
+++ b/PerfectNumbers.Core.Tests/MersenneDivisorCyclesGenerateGpuTests.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using PerfectNumbers.Core;
+using Xunit;
+
+namespace PerfectNumbers.Core.Tests;
+
+public class MersenneDivisorCyclesGenerateGpuTests
+{
+    [Fact]
+    [Trait("Category", "Fast")]
+    public void GenerateGpu_produces_expected_cycles_for_small_range()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            MersenneDivisorCycles.GenerateGpu(path, maxDivisor: 50UL, batchSize: 16, skipCount: 0, nextPosition: 0);
+            var pairs = new List<(ulong divisor, ulong cycle)>();
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read);
+            using var reader = new BinaryReader(stream);
+            while (stream.Position < stream.Length)
+            {
+                ulong d = reader.ReadUInt64();
+                ulong c = reader.ReadUInt64();
+                pairs.Add((d, c));
+            }
+
+            var expected = new List<ulong>();
+            for (ulong d = 3; d <= 50; d++)
+            {
+                if ((d & 1UL) == 0UL || d % 3UL == 0UL || d % 5UL == 0UL || d % 7UL == 0UL || d % 11UL == 0UL)
+                {
+                    continue;
+                }
+
+                expected.Add(d);
+            }
+
+            pairs.Should().HaveCount(expected.Count);
+            foreach (var pair in pairs)
+            {
+                expected.Should().Contain(pair.divisor);
+                pair.cycle.Should().Be(MersenneDivisorCycles.CalculateCycleLength(pair.divisor));
+            }
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/PerfectNumbers.Core.Tests/MersenneNumberResidueGpuTesterTests.cs
+++ b/PerfectNumbers.Core.Tests/MersenneNumberResidueGpuTesterTests.cs
@@ -19,6 +19,7 @@ public class MersenneNumberResidueGpuTesterTests
 
         RunCase(tester, 23UL, 2UL, expectedPrime: false);
         RunCase(tester, 29UL, 37UL, expectedPrime: false);
+        RunCase(tester, 31UL, 1_000UL, expectedPrime: true);
         RunCase(tester, 89UL, 1_001UL, expectedPrime: true);
         RunCase(tester, 127UL, 1_001UL, expectedPrime: true);
     }

--- a/PerfectNumbers.Core/MersenneDivisorCycles.cs
+++ b/PerfectNumbers.Core/MersenneDivisorCycles.cs
@@ -280,10 +280,10 @@ public class MersenneDivisorCycles
 				var bufferDiv = accelerator.Allocate1D(validDivisors);
 				var bufferCycle = accelerator.Allocate1D<ulong>(idx);
 
-				kernel(
-					count,
-					bufferDiv.View,
-					bufferCycle.View);
+                                kernel(
+                                        idx,
+                                        bufferDiv.View,
+                                        bufferCycle.View);
 
 				accelerator.Synchronize();
 


### PR DESCRIPTION
## Summary
- avoid out-of-bounds access when computing divisor cycles on the GPU by launching the kernel with the actual divisor count
- test Mersenne residue GPU path for exponent 31
- add regression test to validate GPU divisor cycle generation

## Testing
- `timeout 120s dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName~MersenneNumberResidueGpuTesterTests|FullyQualifiedName~MersenneDivisorCyclesGenerateGpuTests|FullyQualifiedName~MersenneDivisorCyclesTests"`


------
https://chatgpt.com/codex/tasks/task_e_68c53280127483258495bb213d706bc9