### PR TITLE
Fix residue mode to skip incremental scan

### DIFF
--- a/PerfectNumbers.Core.Tests/MersenneNumberTester/MersenneResidueModeTests.cs
+++ b/PerfectNumbers.Core.Tests/MersenneNumberTester/MersenneResidueModeTests.cs
@@ -12,5 +12,12 @@ public class MersenneResidueModeTests
         var tester = new MersenneNumberTester(useResidue: true, useIncremental: false);
         tester.IsMersennePrime(136_000_002UL).Should().BeFalse();
     }
+
+    [Fact]
+    public void IsMersennePrime_residue_mode_accepts_prime_exponent()
+    {
+        var tester = new MersenneNumberTester(useResidue: true, useIncremental: true, maxK: 1_000UL);
+        tester.IsMersennePrime(31UL).Should().BeTrue();
+    }
 }
 


### PR DESCRIPTION
## Summary
- avoid incremental scanning when running Mersenne tests in residue mode
- cap divisor search by configured limit and return residue result directly
- verify residue mode accepts known Mersenne prime

## Testing
- `dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter FullyQualifiedName~MersenneResidueModeTests`
- `dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter FullyQualifiedName~MersenneNumberResidueGpuTesterTests`
- `dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter FullyQualifiedName~MersenneNumberIncrementalGpuTesterTests`

------
https://chatgpt.com/codex/tasks/task_e_68c5380455d08325b9c201e43943318d