### PR TITLE
Optimize GPU residue scanning and divisor path

### DIFF
--- a/EvenPerfectBitScanner.Tests/ProgramTests.cs
+++ b/EvenPerfectBitScanner.Tests/ProgramTests.cs
@@ -73,14 +73,14 @@ public class ProgramTests
         var useDivisorField = typeof(Program).GetField("_useDivisor", BindingFlags.NonPublic | BindingFlags.Static)!;
         var divisorField = typeof(Program).GetField("_divisor", BindingFlags.NonPublic | BindingFlags.Static)!;
         var testerField = typeof(Program).GetField("_divisorTester", BindingFlags.NonPublic | BindingFlags.Static)!;
-        var candidatesField = typeof(Program).GetField("_divisorCandidates", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var candidatesField = typeof(MersenneNumberDivisorGpuTester).GetField("_divisorCandidates", BindingFlags.NonPublic | BindingFlags.Static)!;
         var primeField = typeof(Program).GetField("PrimeTesters", BindingFlags.NonPublic | BindingFlags.Static)!;
         var residueField = typeof(Program).GetField("PResidue", BindingFlags.NonPublic | BindingFlags.Static)!;
         var forceCpuProp = typeof(GpuContextPool).GetProperty("ForceCpu");
 
         useDivisorField.SetValue(null, true);
         divisorField.SetValue(null, 0UL);
-        testerField.SetValue(null, null);
+        testerField.SetValue(null, new MersenneNumberDivisorGpuTester());
         primeField.SetValue(null, new ThreadLocal<PrimeTester>(() => new PrimeTester(), trackAllValues: true));
         residueField.SetValue(null, new ThreadLocal<ModResidueTracker>(() => new ModResidueTracker(ResidueModel.Identity, 2UL, true), trackAllValues: true));
         candidatesField.SetValue(null, new (ulong, uint)[] { (7UL, 3U), (23UL, 11U) });
@@ -90,6 +90,7 @@ public class ProgramTests
         {
             Program.IsEvenPerfectCandidate(11UL, 32).Should().BeFalse();
             Program.IsEvenPerfectCandidate(5UL, 32).Should().BeTrue();
+            Program.IsEvenPerfectCandidate(127UL, 32).Should().BeTrue();
         }
         finally
         {

--- a/PerfectNumbers.Core.Tests/PrimeTester/PrimeTesterIsPrimeTests.cs
+++ b/PerfectNumbers.Core.Tests/PrimeTester/PrimeTesterIsPrimeTests.cs
@@ -12,6 +12,7 @@ public class PrimeTesterIsPrimeTests
     [InlineData(2UL, true)]
     [InlineData(3UL, true)]
     [InlineData(4UL, false)]
+    [InlineData(5UL, true)]
     [InlineData(7UL, true)]
     [InlineData(97UL, true)]
     [InlineData(121UL, false)]

--- a/PerfectNumbers.Core/Gpu/MersenneNumberResidueGpuTester.cs
+++ b/PerfectNumbers.Core/Gpu/MersenneNumberResidueGpuTester.cs
@@ -15,26 +15,32 @@ public class MersenneNumberResidueGpuTester(bool useGpuOrder)
 	public void Scan(ulong exponent, UInt128 twoP, bool lastIsSeven, UInt128 maxK, ref bool isPrime)
 	{
 		var gpuLease = GpuKernelPool.GetKernel(_useGpuOrder);
-		var accelerator = gpuLease.Accelerator;
-		// Ensure device has small cycles table for in-kernel lookup
-		var smallCyclesView = GpuKernelPool.EnsureSmallCyclesOnDevice(accelerator);
-		int batchSize = GpuConstants.ScanBatchSize;
-		UInt128 kStart = 1UL;
-		byte last = lastIsSeven ? (byte)1 : (byte)0;
-		var kernel = gpuLease.Pow2ModKernel;
+                var accelerator = gpuLease.Accelerator;
+                // Ensure device has small cycles and primes tables for in-kernel lookup
+                var smallCyclesView = GpuKernelPool.EnsureSmallCyclesOnDevice(accelerator);
+                var (smallPrimesView, smallPrimesPow2View) = GpuKernelPool.EnsureSmallPrimesOnDevice(accelerator);
+                int batchSize = GpuConstants.ScanBatchSize;
+                UInt128 kStart = 1UL;
+                byte last = lastIsSeven ? (byte)1 : (byte)0;
+                var kernel = gpuLease.Pow2ModKernel;
+                ulong step10 = ((exponent % 10UL) << 1) % 10UL;
+                ulong step8 = ((exponent & 7UL) << 1) & 7UL;
+                ulong step3 = ((exponent % 3UL) << 1) % 3UL;
+                ulong step5 = ((exponent % 5UL) << 1) % 5UL;
+                GpuUInt128 twoPGpu = (GpuUInt128)twoP;
 
-		var orderBuffer = accelerator.Allocate1D<ulong>(batchSize);
-		ulong[] orderArray = ArrayPool<ulong>.Shared.Rent(batchSize);
-		UInt128 remaining;
-		int currentSize;
-		int i;
-		UInt128 batchSize128 = (UInt128)batchSize, q;
-		Span<ulong> orders = orderArray.AsSpan(0, batchSize);
-		try
-		{
-			while (kStart < maxK && Volatile.Read(ref isPrime))
-			{
-				remaining = maxK - kStart;
+                var orderBuffer = accelerator.Allocate1D<ulong>(batchSize);
+                ulong[] orderArray = ArrayPool<ulong>.Shared.Rent(batchSize);
+                UInt128 remaining;
+                int currentSize;
+                int i;
+                UInt128 batchSize128 = (UInt128)batchSize, q;
+                Span<ulong> orders = orderArray.AsSpan(0, batchSize);
+                try
+                {
+                        while (kStart < maxK && Volatile.Read(ref isPrime))
+                        {
+                                remaining = maxK - kStart;
 				if (remaining > batchSize128)
 				{
 					currentSize = batchSize;
@@ -45,39 +51,35 @@ public class MersenneNumberResidueGpuTester(bool useGpuOrder)
 					orders = orderArray.AsSpan(0, currentSize);
 				}
 
-				q = twoP * kStart + UInt128.One;
-				q.Mod10_8_5_3(out ulong q0m10, out ulong q0m8, out ulong q0m5, out ulong q0m3);
-				ulong step10 = ((exponent % 10UL) << 1) % 10UL;
-				ulong step8 = ((exponent & 7UL) << 1) & 7UL;
-				ulong step3 = ((exponent % 3UL) << 1) % 3UL;
-				ulong step5 = ((exponent % 5UL) << 1) % 5UL;
+                                q = twoP * kStart + UInt128.One;
+                                q.Mod10_8_5_3(out ulong q0m10, out ulong q0m8, out ulong q0m5, out ulong q0m3);
+                                var ra = new ResidueAutomatonArgs(q0m10, step10, q0m8, step8, q0m3, step3, q0m5, step5);
 
-				kernel(currentSize, exponent, (GpuUInt128)twoP, (GpuUInt128)kStart, last, 0UL,
-					q0m10, q0m8, q0m3, q0m5, orderBuffer.View, smallCyclesView);
+                                kernel(currentSize, exponent, twoPGpu, (GpuUInt128)kStart, last, 0UL,
+                                        ra, orderBuffer.View, smallCyclesView, smallPrimesView, smallPrimesPow2View);
 
-				accelerator.Synchronize();
-				orderBuffer.View.CopyToCPU(ref MemoryMarshal.GetReference(orders), currentSize);
-				accelerator.Synchronize();
-				if (!Volatile.Read(ref isPrime))
-				{
-					break;
-				}
+                                accelerator.Synchronize();
+                                orderBuffer.View.CopyToCPU(ref MemoryMarshal.GetReference(orders), currentSize);
+                                if (!Volatile.Read(ref isPrime))
+                                {
+                                        break;
+                                }
 
-				for (i = 0; i < currentSize; i++, q += twoP)
-				{
-					if (orders[i] != 0UL && q.IsPrimeCandidate())
-					{
-						Volatile.Write(ref isPrime, false);
-						break;
-					}
-				}
+                                for (i = 0; i < currentSize; i++)
+                                {
+                                        if (orders[i] != 0UL)
+                                        {
+                                                Volatile.Write(ref isPrime, false);
+                                                break;
+                                        }
+                                }
 
-				kStart += batchSize128;
-			}
-		}
-		finally
-		{
-			ArrayPool<ulong>.Shared.Return(orderArray);
+                                kStart += batchSize128;
+                        }
+                }
+                finally
+                {
+                        ArrayPool<ulong>.Shared.Return(orderArray);
 			orderBuffer.Dispose();
 			gpuLease.Dispose();
 		}

--- a/PerfectNumbers.Core/PrimeTester.cs
+++ b/PerfectNumbers.Core/PrimeTester.cs
@@ -42,7 +42,7 @@ public sealed class PrimeTester(bool useInternal = false)
         {
             result = false;
         }
-        else if (n % 5 == 0)
+        else if (n > 5UL && (n % 5UL) == 0UL)
         {
             result = false;
         }


### PR DESCRIPTION
## Summary
- Precompute residue automaton steps and buffer 2p for GPU residue scans while removing redundant host synchronization
- Reject non-prime residue divisors entirely on GPU using uploaded small prime tables
- Cache GPU result buffers and skip trivial Mersenne matches in divisor checks
- Streamlined 128-bit modulo and residue setup, and fixed prime tester edge cases with new positive divisor-mode tests

## Testing
- `dotnet build EvenPerfectScanner.sln`
- `dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName~PrimeTesterIsPrimeTests"`
- `dotnet test EvenPerfectBitScanner.Tests/EvenPerfectBitScanner.Tests.csproj -c Debug --filter "FullyQualifiedName~ProgramTests"`


------
https://chatgpt.com/codex/tasks/task_e_68c56e8b76bc83258656d24111ea30c7