### PR TITLE
Handle 128-bit divisors in Mersenne scans

### DIFF
--- a/EvenPerfectBitScanner/Program.cs
+++ b/EvenPerfectBitScanner/Program.cs
@@ -25,8 +25,8 @@ internal static class Program
 	private static int _primeCount;
 	private static bool _primeFoundAfterInit;
 	private static bool _useGcdFilter;
-	private static bool _useDivisor;
-	private static ulong _divisor;
+        private static bool _useDivisor;
+        private static UInt128 _divisor;
 	private static MersenneNumberDivisorGpuTester? _divisorTester;
 	private static ulong? _orderWarmupLimitOverride;
 	private static unsafe delegate*<ulong, ref ulong, ulong> _transformP;
@@ -58,9 +58,9 @@ internal static class Program
 		bool showHelp = false;
 		bool useBitTransform = false;
 		bool useLucas = false;
-		bool useResidue = false;    // M_p test via residue divisors (replaces LL/incremental)
-		bool useDivisor = false;     // M_p divisibility by specific divisor
-		ulong divisor = 0UL;
+                bool useResidue = false;    // M_p test via residue divisors (replaces LL/incremental)
+                bool useDivisor = false;     // M_p divisibility by specific divisor
+                UInt128 divisor = UInt128.Zero;
 		// Device routing
 		bool useGpuCycles = true;
 		bool mersenneOnGpu = true;   // controls Lucas/incremental/pow2mod device
@@ -69,9 +69,9 @@ internal static class Program
 		ulong residueKMax = 5_000_000UL;
 		string filterFile = string.Empty;
 		string cyclesPath = DefaultCyclesPath;
-		int cyclesBatchSize = 512;
-		bool continueCyclesGeneration = false;
-		int divisorCyclesSearchLimit = PerfectNumberConstants.ExtraDivisorCycleSearchLimit;
+                int cyclesBatchSize = 512;
+                bool continueCyclesGeneration = false;
+                ulong divisorCyclesSearchLimit = PerfectNumberConstants.ExtraDivisorCycleSearchLimit;
 
 		// NTT backend selection (GPU): reference vs staged
 		for (int i = 0; i < args.Length; i++)
@@ -128,16 +128,16 @@ internal static class Program
 					kernelType = GpuKernelType.Incremental;
 				}
 			}
-			else if (arg.StartsWith("--divisor=", StringComparison.OrdinalIgnoreCase))
-			{
-				int eq = arg.IndexOf('=');
-				divisor = ulong.Parse(arg.AsSpan(eq + 1));
-			}
-			else if (arg.StartsWith("--divisor-cycles-limit=", StringComparison.OrdinalIgnoreCase))
-			{
-				int eq = arg.IndexOf('=');
-				divisorCyclesSearchLimit = int.Parse(arg.AsSpan(eq + 1));
-			}
+                        else if (arg.StartsWith("--divisor=", StringComparison.OrdinalIgnoreCase))
+                        {
+                                int eq = arg.IndexOf('=');
+                                divisor = UInt128.Parse(arg.AsSpan(eq + 1));
+                        }
+                        else if (arg.StartsWith("--divisor-cycles-limit=", StringComparison.OrdinalIgnoreCase))
+                        {
+                                int eq = arg.IndexOf('=');
+                                divisorCyclesSearchLimit = ulong.Parse(arg.AsSpan(eq + 1));
+                        }
 			else if (arg.StartsWith("--residue-max-k=", StringComparison.OrdinalIgnoreCase))
 			{
 				int eq = arg.IndexOf('=');
@@ -438,15 +438,15 @@ internal static class Program
 				return tester;
 			}, trackAllValues: true);
 		}
-		else
-		{
-			if (divisor == 0UL)
-			{
-				MersenneNumberDivisorGpuTester.BuildDivisorCandidates();
-			}
+                else
+                {
+                        if (divisor == UInt128.Zero)
+                        {
+                                MersenneNumberDivisorGpuTester.BuildDivisorCandidates();
+                        }
 
-			_divisorTester = new MersenneNumberDivisorGpuTester();
-		}
+                        _divisorTester = new MersenneNumberDivisorGpuTester();
+                }
 
 		// Load RLE blacklist (optional)
 		if (!string.IsNullOrEmpty(_rleBlacklistPath))
@@ -906,10 +906,10 @@ internal static class Program
 		return next + value;
 	}
 
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	internal static bool IsEvenPerfectCandidate(ulong p, int divisorCyclesSearchLimit) => IsEvenPerfectCandidate(p, divisorCyclesSearchLimit, out _, out _);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsEvenPerfectCandidate(ulong p, ulong divisorCyclesSearchLimit) => IsEvenPerfectCandidate(p, divisorCyclesSearchLimit, out _, out _);
 
-	internal static bool IsEvenPerfectCandidate(ulong p, int divisorCyclesSearchLimit, out bool searchedMersenne, out bool detailedCheck)
+        internal static bool IsEvenPerfectCandidate(ulong p, ulong divisorCyclesSearchLimit, out bool searchedMersenne, out bool detailedCheck)
 	{
 		searchedMersenne = false;
 		detailedCheck = false;
@@ -972,15 +972,15 @@ internal static class Program
 			return false;
 		}
 
-		searchedMersenne = true;
-		if (_useDivisor)
-		{
-			return _divisorTester!.IsPrime(p, _divisor, divisorCyclesSearchLimit, out detailedCheck);
-		}
+                searchedMersenne = true;
+                if (_useDivisor)
+                {
+                        return _divisorTester!.IsPrime(p, _divisor, divisorCyclesSearchLimit, out detailedCheck);
+                }
 
-		detailedCheck = MersenneTesters.Value!.IsMersennePrime(p);
-		return detailedCheck;
-	}
+                detailedCheck = MersenneTesters.Value!.IsMersennePrime(p);
+                return detailedCheck;
+        }
 
 	// Use ModResidueTracker with a small set of primes to pre-filter composite p.
 	private static bool IsCompositeByResidues(ulong p)

--- a/PerfectNumbers.Core.Tests/MersenneNumberDivisorGpuTesterTests.cs
+++ b/PerfectNumbers.Core.Tests/MersenneNumberDivisorGpuTesterTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
 using PerfectNumbers.Core.Gpu;
+using System.Numerics;
+using System.Reflection;
 using Xunit;
 
 namespace PerfectNumbers.Core.Tests;
@@ -17,4 +19,46 @@ public class MersenneNumberDivisorGpuTesterTests
         var tester = new MersenneNumberDivisorGpuTester();
         tester.IsDivisible(exponent, divisor).Should().Be(expected);
     }
+
+    [Fact]
+    [Trait("Category", "Fast")]
+    public void IsDivisible_handles_large_divisors()
+    {
+        var tester = new MersenneNumberDivisorGpuTester();
+        UInt128 divisor = (UInt128.One << 65) - UInt128.One;
+        tester.IsDivisible(65UL, divisor).Should().BeTrue();
+        tester.IsDivisible(65UL, divisor + 2).Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "Fast")]
+    public void IsPrime_sets_divisorsExhausted_false_when_search_range_not_exhausted()
+    {
+        var tester = new MersenneNumberDivisorGpuTester();
+        typeof(MersenneNumberDivisorGpuTester)
+            .GetField("_divisorCandidates", BindingFlags.NonPublic | BindingFlags.Static)!
+            .SetValue(null, Array.Empty<(ulong, uint)>());
+
+        tester.IsPrime(11UL, UInt128.Zero, 0UL, out bool divisorsExhausted).Should().BeTrue();
+        divisorsExhausted.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "Fast")]
+    public void IsPrime_sets_divisorsExhausted_true_when_divisible_by_specified_divisor()
+    {
+        var tester = new MersenneNumberDivisorGpuTester();
+        tester.IsPrime(3UL, 7UL, 0UL, out bool divisorsExhausted).Should().BeFalse();
+        divisorsExhausted.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "Fast")]
+    public void IsPrime_accepts_large_search_limits()
+    {
+        var tester = new MersenneNumberDivisorGpuTester();
+        tester.IsPrime(3UL, 7UL, ulong.MaxValue, out bool exhausted).Should().BeFalse();
+        exhausted.Should().BeTrue();
+    }
 }
+

--- a/PerfectNumbers.Core/PerfectNumberConstants.cs
+++ b/PerfectNumbers.Core/PerfectNumberConstants.cs
@@ -5,6 +5,6 @@ public static class PerfectNumberConstants
 	public const ulong BiggestKnownEvenPerfectP = 136279841UL;
 	public static readonly uint PrimesLimit = 1_000_000; //(ulong)Array.MaxLength;// 1_000_000;
 	public const int MaxQForDivisorCycles = 4_000_000;
-	public const int ExtraDivisorCycleSearchLimit = 64;
+        public const ulong ExtraDivisorCycleSearchLimit = 64UL;
 
 }


### PR DESCRIPTION
## Summary
- allow the bit scanner to parse and propagate 128-bit divisor limits
- extend the GPU divisor tester to scan all possible divisors when the cycle limit permits
- validate large-limit handling and updated completion flags

## Testing
- `timeout 120s dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName~MersenneNumberDivisorGpuTesterTests"`
- `timeout 120s dotnet test EvenPerfectBitScanner.Tests/EvenPerfectBitScanner.Tests.csproj -c Debug --filter "Category=Fast"`


------
https://chatgpt.com/codex/tasks/task_e_68c7f3a512fc8325952eee8d7bf19ba5