### PR TITLE
Refine GPU residue prime tables

### DIFF
--- a/PerfectNumbers.Core.Tests/PrimesGeneratorTests.cs
+++ b/PerfectNumbers.Core.Tests/PrimesGeneratorTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using PerfectNumbers.Core;
 using Xunit;
 
 namespace PerfectNumbers.Core.Tests;
@@ -18,6 +19,45 @@ public class PrimesGeneratorTests
         for (int i = 0; i < 5; i++)
         {
             squares[i].Should().Be(primes[i] * primes[i]);
+        }
+
+        primes.Length.Should().Be((int)PerfectNumberConstants.PrimesLimit);
+        squares.Length.Should().Be((int)PerfectNumberConstants.PrimesLimit);
+    }
+
+    [Fact]
+    [Trait("Category", "Fast")]
+    public void Residue_prime_tables_follow_digit_rules()
+    {
+        var lastOne = PrimesGenerator.SmallPrimesLastOne;
+        var lastOnePow2 = PrimesGenerator.SmallPrimesPow2LastOne;
+        var lastSeven = PrimesGenerator.SmallPrimesLastSeven;
+        var lastSevenPow2 = PrimesGenerator.SmallPrimesPow2LastSeven;
+
+        lastOne.Length.Should().Be((int)PerfectNumberConstants.PrimesLimit);
+        lastSeven.Length.Should().Be((int)PerfectNumberConstants.PrimesLimit);
+        lastOnePow2.Length.Should().Be(lastOne.Length);
+        lastSevenPow2.Length.Should().Be(lastSeven.Length);
+
+        lastOne[..5].Should().Equal([3U, 7U, 11U, 13U, 19U]);
+        lastSeven[..5].Should().Equal([3U, 7U, 11U, 13U, 17U]);
+
+        for (int i = 0; i < lastOne.Length; i++)
+        {
+            uint prime = lastOne[i];
+            uint mod10 = prime % 10U;
+            (mod10 == 1U || mod10 == 3U || mod10 == 9U || prime == 7U || prime == 11U)
+                .Should().BeTrue();
+            lastOnePow2[i].Should().Be(prime * (ulong)prime);
+        }
+
+        for (int i = 0; i < lastSeven.Length; i++)
+        {
+            uint prime = lastSeven[i];
+            uint mod10 = prime % 10U;
+            (mod10 == 3U || mod10 == 7U || mod10 == 9U || prime == 11U)
+                .Should().BeTrue();
+            lastSevenPow2[i].Should().Be(prime * (ulong)prime);
         }
     }
 }

--- a/PerfectNumbers.Core/Gpu/MersenneNumberIncrementalGpuTester.cs
+++ b/PerfectNumbers.Core/Gpu/MersenneNumberIncrementalGpuTester.cs
@@ -27,11 +27,10 @@ public class MersenneNumberIncrementalGpuTester(GpuKernelType kernelType, bool u
                 ulong step5 = ((exponent % 5UL) << 1) % 5UL;
                 GpuUInt128 twoPGpu = (GpuUInt128)twoP;
                 var smallCyclesView = GpuKernelPool.EnsureSmallCyclesOnDevice(accelerator);
-                ArrayView1D<uint, Stride1D.Dense> smallPrimesView = default;
-                ArrayView1D<ulong, Stride1D.Dense> smallPrimesPow2View = default;
+                ResiduePrimeViews primeViews = default;
                 if (_kernelType == GpuKernelType.Pow2Mod)
                 {
-                        (smallPrimesView, smallPrimesPow2View) = GpuKernelPool.EnsureSmallPrimesOnDevice(accelerator);
+                        primeViews = GpuKernelPool.EnsureSmallPrimesOnDevice(accelerator);
                 }
 
                 var orderBuffer = accelerator.Allocate1D<ulong>(batchSize);
@@ -56,7 +55,7 @@ public class MersenneNumberIncrementalGpuTester(GpuKernelType kernelType, bool u
                                         q0.Mod10_8_5_3(out ulong q0m10, out ulong q0m8, out ulong q0m5, out ulong q0m3);
                                         var ra = new ResidueAutomatonArgs(q0m10, step10, q0m8, step8, q0m3, step3, q0m5, step5);
                                         pow2Kernel(currentSize, exponent, twoPGpu, (GpuUInt128)kStart, last, divMul,
-                                                ra, orderBuffer.View, smallCyclesView, smallPrimesView, smallPrimesPow2View);
+                                                ra, orderBuffer.View, smallCyclesView, primeViews.LastOne, primeViews.LastSeven, primeViews.LastOnePow2, primeViews.LastSevenPow2);
                                 }
                                 else
                                 {

--- a/PerfectNumbers.Core/Gpu/MersenneNumberResidueGpuTester.cs
+++ b/PerfectNumbers.Core/Gpu/MersenneNumberResidueGpuTester.cs
@@ -18,7 +18,7 @@ public class MersenneNumberResidueGpuTester(bool useGpuOrder)
                 var accelerator = gpuLease.Accelerator;
                 // Ensure device has small cycles and primes tables for in-kernel lookup
                 var smallCyclesView = GpuKernelPool.EnsureSmallCyclesOnDevice(accelerator);
-                var (smallPrimesView, smallPrimesPow2View) = GpuKernelPool.EnsureSmallPrimesOnDevice(accelerator);
+                ResiduePrimeViews primeViews = GpuKernelPool.EnsureSmallPrimesOnDevice(accelerator);
                 int batchSize = GpuConstants.ScanBatchSize;
                 UInt128 kStart = 1UL;
                 byte last = lastIsSeven ? (byte)1 : (byte)0;
@@ -56,7 +56,7 @@ public class MersenneNumberResidueGpuTester(bool useGpuOrder)
                                 var ra = new ResidueAutomatonArgs(q0m10, step10, q0m8, step8, q0m3, step3, q0m5, step5);
 
                                 kernel(currentSize, exponent, twoPGpu, (GpuUInt128)kStart, last, 0UL,
-                                        ra, orderBuffer.View, smallCyclesView, smallPrimesView, smallPrimesPow2View);
+                                        ra, orderBuffer.View, smallCyclesView, primeViews.LastOne, primeViews.LastSeven, primeViews.LastOnePow2, primeViews.LastSevenPow2);
 
                                 accelerator.Synchronize();
                                 orderBuffer.View.CopyToCPU(ref MemoryMarshal.GetReference(orders), currentSize);

--- a/PerfectNumbers.Core/PrimesGenerator.cs
+++ b/PerfectNumbers.Core/PrimesGenerator.cs
@@ -1,80 +1,113 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
 namespace PerfectNumbers.Core;
 
 public static class PrimesGenerator
 {
-	private static uint[]? _primes;
-	private static ulong[]? _primesPow2;
+public static readonly uint[] SmallPrimes;
+public static readonly ulong[] SmallPrimesPow2;
+public static readonly uint[] SmallPrimesLastOne;
+public static readonly ulong[] SmallPrimesPow2LastOne;
+public static readonly uint[] SmallPrimesLastSeven;
+public static readonly ulong[] SmallPrimesPow2LastSeven;
 
-	public static readonly uint[] SmallPrimes = BuildSmallPrimesInternal();
-	public static readonly ulong[] SmallPrimesPow2 = BuildSmallPrimesPow2Internal();
+static PrimesGenerator()
+{
+BuildSmallPrimes(
+out SmallPrimes,
+out SmallPrimesPow2,
+out SmallPrimesLastOne,
+out SmallPrimesPow2LastOne,
+out SmallPrimesLastSeven,
+out SmallPrimesPow2LastSeven);
+}
 
+private static void BuildSmallPrimes(
+out uint[] all,
+out ulong[] allPow2,
+out uint[] lastOne,
+out ulong[] lastOnePow2,
+out uint[] lastSeven,
+out ulong[] lastSevenPow2)
+{
+uint target = PerfectNumberConstants.PrimesLimit;
+int targetInt = checked((int)target);
+all = new uint[targetInt];
+allPow2 = new ulong[targetInt];
+lastOne = new uint[targetInt];
+lastOnePow2 = new ulong[targetInt];
+lastSeven = new uint[targetInt];
+lastSevenPow2 = new ulong[targetInt];
 
-	private static uint[] BuildSmallPrimesInternal()
-	{
-		if (_primes == null)
-		{
-			BuildSmallPrimes();
-		}
+List<uint> primes = new(targetInt * 4 / 3 + 16);
+uint candidate = 2U;
+int allCount = 0;
+int lastOneCount = 0;
+int lastSevenCount = 0;
 
-		return _primes!;
-	}
+while (allCount < targetInt || lastOneCount < targetInt || lastSevenCount < targetInt)
+{
+bool isPrime = true;
+int primesCount = primes.Count;
+for (int i = 0; i < primesCount; i++)
+{
+uint p = primes[i];
+if (p * p > candidate)
+{
+break;
+}
 
-	private static ulong[] BuildSmallPrimesPow2Internal()
-	{
-		if (_primesPow2 == null)
-		{
-			BuildSmallPrimes();
-		}
+if (candidate % p == 0U)
+{
+isPrime = false;
+break;
+}
+}
 
-		return _primesPow2!;
-	}
+if (isPrime)
+{
+primes.Add(candidate);
+if (allCount < targetInt)
+{
+all[allCount] = candidate;
+allPow2[allCount] = checked((ulong)candidate * candidate);
+allCount++;
+}
 
-	private static void BuildSmallPrimes()
-	{
-		uint limit = PerfectNumberConstants.PrimesLimit;
-		var primes = new uint[limit];
-		primes[0] = 2;
-		var primesPow2 = new ulong[limit];
-		primesPow2[0] = 4;
+if (candidate != 2U)
+{
+if (lastOneCount < targetInt && IsAllowedForLastOne(candidate))
+{
+lastOne[lastOneCount] = candidate;
+lastOnePow2[lastOneCount] = checked((ulong)candidate * candidate);
+lastOneCount++;
+}
 
-		int j;
-		uint i = 3, p, sqrt;
-		bool isPrime;
-		int primeIndex = 1;
+if (lastSevenCount < targetInt && IsAllowedForLastSeven(candidate))
+{
+lastSeven[lastSevenCount] = candidate;
+lastSevenPow2[lastSevenCount] = checked((ulong)candidate * candidate);
+lastSevenCount++;
+}
+}
+}
 
-		for (; i <= limit; i += 2)
-		{
-			isPrime = true;
-			sqrt = (uint)Math.Sqrt(i);
-			for (j = 0; j < primeIndex; j++)
-			{
-				p = primes[j];
-				if (p > sqrt)
-				{
-					break;
-				}
+candidate = candidate == 2U ? 3U : candidate + 2U;
+}
+}
 
-				if (i % p == 0UL)
-				{
-					isPrime = false;
-					break;
-				}
-			}
+[MethodImpl(MethodImplOptions.AggressiveInlining)]
+private static bool IsAllowedForLastOne(uint prime)
+{
+uint mod10 = prime % 10U;
+return mod10 == 1U || mod10 == 3U || mod10 == 9U || prime == 7U || prime == 11U;
+}
 
-			if (isPrime)
-			{
-				primes[primeIndex] = i;
-				primesPow2[primeIndex] = checked((ulong)i * i);
-				primeIndex++;
-			}
-		}
-
-		Array.Resize(ref primes, primeIndex);
-		Array.Resize(ref primesPow2, primeIndex);
-
-		_primes = primes;
-		_primesPow2 = primesPow2;
-
-		return;
-	}
+[MethodImpl(MethodImplOptions.AggressiveInlining)]
+private static bool IsAllowedForLastSeven(uint prime)
+{
+uint mod10 = prime % 10U;
+return mod10 == 3U || mod10 == 7U || mod10 == 9U || prime == 11U;
+}
 }


### PR DESCRIPTION
## Summary
- generate separate residue prime tables for Mersenne numbers ending in 1 and 7 while treating PrimesLimit as a count
- update GPU residue kernels to select the appropriate divisor table and upload the new buffers to accelerators
- extend prime generator tests to validate the digit rules and table sizes

## Testing
- dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Release --filter "FullyQualifiedName~PrimesGeneratorTests"


------
https://chatgpt.com/codex/tasks/task_e_68cad150790883258b6f72b22790f0da