### PR TITLE
Report residue scan exhaustion through detailed checks

### DIFF
--- a/PerfectNumbers.Core.Tests/MersenneNumberResidueCpuTesterTests.cs
+++ b/PerfectNumbers.Core.Tests/MersenneNumberResidueCpuTesterTests.cs
@@ -24,8 +24,18 @@ public class MersenneNumberResidueCpuTesterTests
     private static void RunCase(MersenneNumberResidueCpuTester tester, ulong exponent, ulong maxK, bool expectedPrime)
     {
         bool isPrime = true;
-        tester.Scan(exponent, (UInt128)exponent << 1, LastDigitIsSeven(exponent), (UInt128)maxK, ref isPrime);
+        bool exhausted = false;
+        tester.Scan(
+                exponent,
+                (UInt128)exponent << 1,
+                LastDigitIsSeven(exponent),
+                (UInt128)maxK,
+                1UL,
+                (UInt128)maxK,
+                ref isPrime,
+                ref exhausted);
         isPrime.Should().Be(expectedPrime);
+        exhausted.Should().BeTrue();
     }
 }
 

--- a/PerfectNumbers.Core.Tests/MersenneNumberResidueGpuTesterTests.cs
+++ b/PerfectNumbers.Core.Tests/MersenneNumberResidueGpuTesterTests.cs
@@ -27,8 +27,18 @@ public class MersenneNumberResidueGpuTesterTests
     private static void RunCase(MersenneNumberResidueGpuTester tester, ulong exponent, ulong maxK, bool expectedPrime)
     {
         bool isPrime = true;
-        tester.Scan(exponent, (UInt128)exponent << 1, LastDigitIsSeven(exponent), (UInt128)maxK, ref isPrime);
+        bool exhausted = false;
+        tester.Scan(
+                exponent,
+                (UInt128)exponent << 1,
+                LastDigitIsSeven(exponent),
+                (UInt128)maxK,
+                1UL,
+                (UInt128)maxK,
+                ref isPrime,
+                ref exhausted);
         isPrime.Should().Be(expectedPrime);
+        exhausted.Should().BeTrue();
     }
 }
 

--- a/PerfectNumbers.Core/Cpu/MersenneNumberResidueCpuTester.cs
+++ b/PerfectNumbers.Core/Cpu/MersenneNumberResidueCpuTester.cs
@@ -5,25 +5,32 @@ public class MersenneNumberResidueCpuTester
 	private ModResidueTracker? _mersenneResidueTracker;
 
 	// CPU residue variant using tracker + unrolled residue updates (no method calls in the loop).
-	public void Scan(ulong exponent, UInt128 twoP, bool lastIsSeven, UInt128 maxK, ref bool isPrime)
-	{
-		// Initialize/update Mersenne residue tracker and start a merge walk for ascending q divisors
+    public void Scan(
+            ulong exponent,
+            UInt128 twoP,
+            bool lastIsSeven,
+            UInt128 perSetLimit,
+            ulong setCount,
+            UInt128 overallLimit,
+            ref bool isPrime,
+            ref bool divisorsExhausted)
+    {
+            if (setCount == 0UL || perSetLimit == UInt128.Zero || overallLimit == UInt128.Zero)
+            {
+                    return;
+            }
 
-		_mersenneResidueTracker ??= new(ResidueModel.Mersenne);
-		// For small divisors q <= 4,000,000 use cached cycle length to fast-path checks
-		// and avoid per-q powmods when possible when scanning lanes.
-		_mersenneResidueTracker.BeginMerge(exponent);
+                // Initialize/update Mersenne residue tracker and start a merge walk for ascending q divisors
 
-		// Start at k = 1: q0 = 2*p*1 + 1
-		UInt128 k = UInt128.One;
-		UInt128 q = twoP + UInt128.One;
-		// Current residues
-		q.Mod10_8_5_3(out ulong r10, out ulong r8, out ulong r5, out ulong r3);
-		// Step residues for q += 2*p
-		ulong step10 = (ulong)(twoP % 10UL) % 10UL;
-		ulong step8 = (ulong)(twoP % 8UL);
-		ulong step3 = (ulong)(twoP % 3UL);
-		ulong step5 = (ulong)(twoP % 5UL);
+                _mersenneResidueTracker ??= new(ResidueModel.Mersenne);
+                // For small divisors q <= 4,000,000 use cached cycle length to fast-path checks
+                // and avoid per-q powmods when possible when scanning lanes.
+                _mersenneResidueTracker.BeginMerge(exponent);
+
+                ulong step10 = (ulong)(twoP % 10UL) % 10UL;
+                ulong step8 = (ulong)(twoP % 8UL);
+                ulong step3 = (ulong)(twoP % 3UL);
+                ulong step5 = (ulong)(twoP % 5UL);
 
 		// Allowed last-digit sets for q depending on last digit of M_p
 		// lastIsSeven == true  => allow {7,9}
@@ -31,139 +38,162 @@ public class MersenneNumberResidueCpuTester
 		int allowMask = lastIsSeven ? CpuConstants.LastSevenMask10 : CpuConstants.LastOneMask10;
 
 		// Predeclare temps to avoid redeclaration overhead in the loop
-		UInt128 remaining;
-		int i, lanes;
-		// per-lane residues
-		ulong r10_0, r10_1, r10_2, r10_3, r8_0, r8_1, r8_2, r8_3, r3_0, r3_1, r3_2, r3_3, r5_0, r5_1, r5_2, r5_3;
-		// q lanes
-		UInt128 twoP2 = twoP + twoP,
-				twoP3 = twoP2 + twoP,
-				twoP4 = twoP3 + twoP,
-				qIncremental;
+                UInt128 remaining;
+                int i, lanes;
+                // per-lane residues
+                ulong r10_0, r10_1, r10_2, r10_3, r8_0, r8_1, r8_2, r8_3, r3_0, r3_1, r3_2, r3_3, r5_0, r5_1, r5_2, r5_3;
+                // q lanes
+                UInt128 twoP2 = twoP + twoP,
+                                twoP3 = twoP2 + twoP,
+                                twoP4 = twoP3 + twoP,
+                                qIncremental;
 
-		bool localIsPrime, isDivider;
+                bool localIsPrime, isDivider;
 
-		maxK++;
+                ModResidueTracker tracker = _mersenneResidueTracker!;
+                UInt128 limitInclusive = overallLimit + UInt128.One;
+                for (ulong setIndex = 0; setIndex < setCount && Volatile.Read(ref isPrime); setIndex++)
+                {
+                        UInt128 setOffset = perSetLimit * (UInt128)setIndex;
+                        UInt128 k = setOffset + UInt128.One;
+                        if (k >= limitInclusive)
+                        {
+                                break;
+                        }
 
-		ModResidueTracker tracker = _mersenneResidueTracker!;
-		while (k < maxK && (localIsPrime = Volatile.Read(ref isPrime)))
-		{
-			remaining = maxK - k;
-			if (remaining == UInt128.Zero)
-			{
-				break;
-			}
+                        UInt128 setLimitExclusive = setOffset + perSetLimit + UInt128.One;
+                        if (setLimitExclusive > limitInclusive)
+                        {
+                                setLimitExclusive = limitInclusive;
+                        }
 
-			lanes = remaining > 4UL ? 4 : (int)remaining;
+                        UInt128 q = twoP * k + UInt128.One;
+                        q.Mod10_8_5_3(out ulong r10, out ulong r8, out ulong r5, out ulong r3);
 
-			// Compute lane residues incrementally (avoid multiplications, minimize reductions)
-			// r10
-			r10_0 = r10;
-			r10_1 = r10_0 + step10; if (r10_1 >= 20UL) r10_1 -= 20UL; if (r10_1 >= 10UL) r10_1 -= 10UL;
-			r10_2 = r10_1 + step10; if (r10_2 >= 20UL) r10_2 -= 20UL; if (r10_2 >= 10UL) r10_2 -= 10UL;
-			r10_3 = r10_2 + step10; if (r10_3 >= 20UL) r10_3 -= 20UL; if (r10_3 >= 10UL) r10_3 -= 10UL;
+                        while (k < setLimitExclusive && (localIsPrime = Volatile.Read(ref isPrime)))
+                        {
+                                remaining = setLimitExclusive - k;
+                                if (remaining == UInt128.Zero)
+                                {
+                                        break;
+                                }
 
-			// r8
-			r8_0 = r8 & 7UL;
-			r8_1 = (r8_0 + step8) & 7UL;
-			r8_2 = (r8_1 + step8) & 7UL;
-			r8_3 = (r8_2 + step8) & 7UL;
+                                lanes = remaining > 4UL ? 4 : (int)remaining;
+                                if (lanes <= 0)
+                                {
+                                        break;
+                                }
 
-			// r3 (pattern 0,1,2,0)
-			r3_0 = r3; if (r3_0 >= 3UL) r3_0 -= 3UL;
-			r3_1 = r3_0 + step3; if (r3_1 >= 3UL) r3_1 -= 3UL;
-			r3_2 = r3_1 + step3; if (r3_2 >= 3UL) r3_2 -= 3UL;
-			r3_3 = r3; if (r3_3 >= 3UL) r3_3 -= 3UL;
+                                // Compute lane residues incrementally (avoid multiplications, minimize reductions)
+                                // r10
+                                r10_0 = r10;
+                                r10_1 = r10_0 + step10; if (r10_1 >= 20UL) r10_1 -= 20UL; if (r10_1 >= 10UL) r10_1 -= 10UL;
+                                r10_2 = r10_1 + step10; if (r10_2 >= 20UL) r10_2 -= 20UL; if (r10_2 >= 10UL) r10_2 -= 10UL;
+                                r10_3 = r10_2 + step10; if (r10_3 >= 20UL) r10_3 -= 20UL; if (r10_3 >= 10UL) r10_3 -= 10UL;
 
-			// r5 (pattern 0,1,2,3)
-			r5_0 = r5; if (r5_0 >= 5UL) r5_0 -= 5UL;
-			r5_1 = r5_0 + step5; if (r5_1 >= 10UL) r5_1 -= 10UL; if (r5_1 >= 5UL) r5_1 -= 5UL;
-			r5_2 = r5_1 + step5; if (r5_2 >= 10UL) r5_2 -= 10UL; if (r5_2 >= 5UL) r5_2 -= 5UL;
-			r5_3 = r5_2 + step5; if (r5_3 >= 10UL) r5_3 -= 10UL; if (r5_3 >= 5UL) r5_3 -= 5UL;
+                                // r8
+                                r8_0 = r8 & 7UL;
+                                r8_1 = (r8_0 + step8) & 7UL;
+                                r8_2 = (r8_1 + step8) & 7UL;
+                                r8_3 = (r8_2 + step8) & 7UL;
 
-			// lane 0
-			if (lanes >= 1 &&
-				(((allowMask >> (int)r10_0) & 1) != 0 && (r8_0 == 1UL || r8_0 == 7UL) && r3_0 != 0UL && r5_0 != 0UL))
-			{
-				// cycle-based quick check for small q
-				if (localIsPrime && tracker.MergeOrAppend(exponent, q, out isDivider) && isDivider &&
-					(q <= ulong.MaxValue ? ((ulong)q).IsPrimeCandidate() : q.IsPrimeCandidate()))
-				{
-					localIsPrime = false;
-				}
-			}
+                                // r3 (pattern 0,1,2,0)
+                                r3_0 = r3; if (r3_0 >= 3UL) r3_0 -= 3UL;
+                                r3_1 = r3_0 + step3; if (r3_1 >= 3UL) r3_1 -= 3UL;
+                                r3_2 = r3_1 + step3; if (r3_2 >= 3UL) r3_2 -= 3UL;
+                                r3_3 = r3; if (r3_3 >= 3UL) r3_3 -= 3UL;
 
-			// lane 1
-			qIncremental = q + twoP;
-			if (lanes >= 2 &&
-				((allowMask >> (int)r10_1) & 1) != 0 && (r8_1 == 1UL || r8_1 == 7UL) && r3_1 != 0UL && r5_1 != 0UL &&
-				localIsPrime)
-			{
-				if (localIsPrime && tracker.MergeOrAppend(exponent, qIncremental, out isDivider) && isDivider &&
-					(qIncremental <= ulong.MaxValue ? ((ulong)qIncremental).IsPrimeCandidate() : qIncremental.IsPrimeCandidate()))
-				{
-					localIsPrime = false;
-				}
-			}
+                                // r5 (pattern 0,1,2,3)
+                                r5_0 = r5; if (r5_0 >= 5UL) r5_0 -= 5UL;
+                                r5_1 = r5_0 + step5; if (r5_1 >= 10UL) r5_1 -= 10UL; if (r5_1 >= 5UL) r5_1 -= 5UL;
+                                r5_2 = r5_1 + step5; if (r5_2 >= 10UL) r5_2 -= 10UL; if (r5_2 >= 5UL) r5_2 -= 5UL;
+                                r5_3 = r5_2 + step5; if (r5_3 >= 10UL) r5_3 -= 10UL; if (r5_3 >= 5UL) r5_3 -= 5UL;
 
-			// lane 2
-			qIncremental += twoP;
-			if (lanes >= 3 &&
-				((allowMask >> (int)r10_2) & 1) != 0 && (r8_2 == 1UL || r8_2 == 7UL) && r3_2 != 0UL && r5_2 != 0UL &&
-				localIsPrime)
-			{
-				if (localIsPrime && tracker.MergeOrAppend(exponent, qIncremental, out isDivider) && isDivider &&
-					(qIncremental <= ulong.MaxValue ? ((ulong)qIncremental).IsPrimeCandidate() : qIncremental.IsPrimeCandidate()))
-				{
-					localIsPrime = false;
-				}
-			}
+                                // lane 0
+                                if (lanes >= 1 &&
+                                        (((allowMask >> (int)r10_0) & 1) != 0 && (r8_0 == 1UL || r8_0 == 7UL) && r3_0 != 0UL && r5_0 != 0UL))
+                                {
+                                        if (localIsPrime && tracker.MergeOrAppend(exponent, q, out isDivider) && isDivider &&
+                                                (q <= ulong.MaxValue ? ((ulong)q).IsPrimeCandidate() : q.IsPrimeCandidate()))
+                                        {
+                                                localIsPrime = false;
+                                        }
+                                }
 
-			// lane 3
-			qIncremental += twoP;
-			if (lanes >= 4 &&
-				((allowMask >> (int)r10_3) & 1) != 0 && (r8_3 == 1UL || r8_3 == 7UL) && r3_3 != 0UL && r5_3 != 0UL &&
-				localIsPrime)
-			{
-				if (localIsPrime && tracker.MergeOrAppend(exponent, qIncremental, out isDivider) && isDivider &&
-					(qIncremental <= ulong.MaxValue ? ((ulong)qIncremental).IsPrimeCandidate() : qIncremental.IsPrimeCandidate()))
-				{
-					localIsPrime = false;
-				}
-			}
+                                // lane 1
+                                qIncremental = q + twoP;
+                                if (lanes >= 2 &&
+                                        ((allowMask >> (int)r10_1) & 1) != 0 && (r8_1 == 1UL || r8_1 == 7UL) && r3_1 != 0UL && r5_1 != 0UL &&
+                                        localIsPrime)
+                                {
+                                        if (localIsPrime && tracker.MergeOrAppend(exponent, qIncremental, out isDivider) && isDivider &&
+                                                (qIncremental <= ulong.MaxValue ? ((ulong)qIncremental).IsPrimeCandidate() : qIncremental.IsPrimeCandidate()))
+                                        {
+                                                localIsPrime = false;
+                                        }
+                                }
 
-			if (!localIsPrime)
-			{
-				Volatile.Write(ref isPrime, false);
-				return;
-			}
-			else if (!Volatile.Read(ref isPrime))
-			{
-				return;
-			}
+                                // lane 2
+                                qIncremental += twoP;
+                                if (lanes >= 3 &&
+                                        ((allowMask >> (int)r10_2) & 1) != 0 && (r8_2 == 1UL || r8_2 == 7UL) && r3_2 != 0UL && r5_2 != 0UL &&
+                                        localIsPrime)
+                                {
+                                        if (localIsPrime && tracker.MergeOrAppend(exponent, qIncremental, out isDivider) && isDivider &&
+                                                (qIncremental <= ulong.MaxValue ? ((ulong)qIncremental).IsPrimeCandidate() : qIncremental.IsPrimeCandidate()))
+                                        {
+                                                localIsPrime = false;
+                                        }
+                                }
 
-			// advance base by processed lanes
-			k += (UInt128)lanes;
-			q += lanes switch
-			{
-				0 => 0UL,
-				1 => twoP,
-				2 => twoP2,
-				3 => twoP3,
-				4 => twoP4,
-				_ => throw new ArgumentException("Unsupproted value", nameof(twoP))
-			};
+                                // lane 3
+                                qIncremental += twoP;
+                                if (lanes >= 4 &&
+                                        ((allowMask >> (int)r10_3) & 1) != 0 && (r8_3 == 1UL || r8_3 == 7UL) && r3_3 != 0UL && r5_3 != 0UL &&
+                                        localIsPrime)
+                                {
+                                        if (localIsPrime && tracker.MergeOrAppend(exponent, qIncremental, out isDivider) && isDivider &&
+                                                (qIncremental <= ulong.MaxValue ? ((ulong)qIncremental).IsPrimeCandidate() : qIncremental.IsPrimeCandidate()))
+                                        {
+                                                localIsPrime = false;
+                                        }
+                                }
 
-			// advance residues by 'lanes' steps (consistent with base advance)
-			for (i = 0; i < lanes; i++)
-			{
-				r10 += step10; if (r10 >= 20UL) r10 -= 20UL; if (r10 >= 10UL) r10 -= 10UL;
-				r8 = (r8 + step8) & 7UL;
-				r3 += step3; if (r3 >= 3UL) r3 -= 3UL;
-				r5 += step5; if (r5 >= 10UL) r5 -= 10UL; if (r5 >= 5UL) r5 -= 5UL;
-			}
-		}
+                                if (!localIsPrime)
+                                {
+                                        Volatile.Write(ref isPrime, false);
+                                        divisorsExhausted = true;
+                                        return;
+                                }
+                                else if (!Volatile.Read(ref isPrime))
+                                {
+                                        divisorsExhausted = true;
+                                        return;
+                                }
 
-		return;
-	}
+                                // advance base by processed lanes
+                                k += (UInt128)lanes;
+                                q += lanes switch
+                                {
+                                        0 => 0UL,
+                                        1 => twoP,
+                                        2 => twoP2,
+                                        3 => twoP3,
+                                        4 => twoP4,
+                                        _ => throw new ArgumentException("Unsupproted value", nameof(twoP))
+                                };
+
+                                // advance residues by 'lanes' steps (consistent with base advance)
+                                for (i = 0; i < lanes; i++)
+                                {
+                                        r10 += step10; if (r10 >= 20UL) r10 -= 20UL; if (r10 >= 10UL) r10 -= 10UL;
+                                        r8 = (r8 + step8) & 7UL;
+                                        r3 += step3; if (r3 >= 3UL) r3 -= 3UL;
+                                        r5 += step5; if (r5 >= 10UL) r5 -= 10UL; if (r5 >= 5UL) r5 -= 5UL;
+                }
+
+                divisorsExhausted = true;
+    }
+}
+        }
 }

--- a/PerfectNumbers.Core/Gpu/MersenneNumberResidueGpuTester.cs
+++ b/PerfectNumbers.Core/Gpu/MersenneNumberResidueGpuTester.cs
@@ -11,16 +11,28 @@ public class MersenneNumberResidueGpuTester(bool useGpuOrder)
 	// candidates without launching heavy kernels. Consider a device-visible constant buffer per-accelerator
 	// via GpuKernelPool to avoid host round-trips.
 
-	// GPU residue variant: check 2^p % q == 1 for q = 2*p*k + 1.
-	public void Scan(ulong exponent, UInt128 twoP, bool lastIsSeven, UInt128 maxK, ref bool isPrime)
-	{
-		var gpuLease = GpuKernelPool.GetKernel(_useGpuOrder);
+        // GPU residue variant: check 2^p % q == 1 for q = 2*p*k + 1.
+    public void Scan(
+            ulong exponent,
+            UInt128 twoP,
+            bool lastIsSeven,
+            UInt128 perSetLimit,
+            ulong setCount,
+            UInt128 overallLimit,
+            ref bool isPrime,
+            ref bool divisorsExhausted)
+    {
+            if (setCount == 0UL || perSetLimit == UInt128.Zero || overallLimit == UInt128.Zero)
+            {
+                    return;
+            }
+
+                var gpuLease = GpuKernelPool.GetKernel(_useGpuOrder);
                 var accelerator = gpuLease.Accelerator;
                 // Ensure device has small cycles and primes tables for in-kernel lookup
                 var smallCyclesView = GpuKernelPool.EnsureSmallCyclesOnDevice(accelerator);
                 ResiduePrimeViews primeViews = GpuKernelPool.EnsureSmallPrimesOnDevice(accelerator);
                 int batchSize = GpuConstants.ScanBatchSize;
-                UInt128 kStart = 1UL;
                 byte last = lastIsSeven ? (byte)1 : (byte)0;
                 var kernel = gpuLease.Pow2ModKernel;
                 ulong step10 = ((exponent % 10UL) << 1) % 10UL;
@@ -31,57 +43,71 @@ public class MersenneNumberResidueGpuTester(bool useGpuOrder)
 
                 var orderBuffer = accelerator.Allocate1D<ulong>(batchSize);
                 ulong[] orderArray = ArrayPool<ulong>.Shared.Rent(batchSize);
-                UInt128 remaining;
-                int currentSize;
-                int i;
-                UInt128 batchSize128 = (UInt128)batchSize, q;
+                UInt128 batchSize128 = (UInt128)batchSize;
+                UInt128 limitInclusive = overallLimit + UInt128.One;
                 Span<ulong> orders = orderArray.AsSpan(0, batchSize);
                 try
                 {
-                        while (kStart < maxK && Volatile.Read(ref isPrime))
+                        for (ulong setIndex = 0; setIndex < setCount && Volatile.Read(ref isPrime); setIndex++)
                         {
-                                remaining = maxK - kStart;
-				if (remaining > batchSize128)
-				{
-					currentSize = batchSize;
-				}
-				else
-				{
-					currentSize = (int)remaining;
-					orders = orderArray.AsSpan(0, currentSize);
-				}
-
-                                q = twoP * kStart + UInt128.One;
-                                q.Mod10_8_5_3(out ulong q0m10, out ulong q0m8, out ulong q0m5, out ulong q0m3);
-                                var ra = new ResidueAutomatonArgs(q0m10, step10, q0m8, step8, q0m3, step3, q0m5, step5);
-
-                                kernel(currentSize, exponent, twoPGpu, (GpuUInt128)kStart, last, 0UL,
-                                        ra, orderBuffer.View, smallCyclesView, primeViews.LastOne, primeViews.LastSeven, primeViews.LastOnePow2, primeViews.LastSevenPow2);
-
-                                accelerator.Synchronize();
-                                orderBuffer.View.CopyToCPU(ref MemoryMarshal.GetReference(orders), currentSize);
-                                if (!Volatile.Read(ref isPrime))
+                                UInt128 setOffset = perSetLimit * (UInt128)setIndex;
+                                UInt128 setStart = setOffset + UInt128.One;
+                                if (setStart >= limitInclusive)
                                 {
                                         break;
                                 }
 
-                                for (i = 0; i < currentSize; i++)
+                                UInt128 setLimitExclusive = setOffset + perSetLimit + UInt128.One;
+                                if (setLimitExclusive > limitInclusive)
                                 {
-                                        if (orders[i] != 0UL)
-                                        {
-                                                Volatile.Write(ref isPrime, false);
-                                                break;
-                                        }
+                                        setLimitExclusive = limitInclusive;
                                 }
 
-                                kStart += batchSize128;
+                                UInt128 kStart = setStart;
+                                while (kStart < setLimitExclusive && Volatile.Read(ref isPrime))
+                                {
+                                        UInt128 remaining = setLimitExclusive - kStart;
+                                        int currentSize = remaining > batchSize128 ? batchSize : (int)remaining;
+                                        if (currentSize <= 0)
+                                        {
+                                                break;
+                                        }
+                                        orders = orderArray.AsSpan(0, currentSize);
+
+                                        UInt128 q = twoP * kStart + UInt128.One;
+                                        q.Mod10_8_5_3(out ulong q0m10, out ulong q0m8, out ulong q0m5, out ulong q0m3);
+                                        var ra = new ResidueAutomatonArgs(q0m10, step10, q0m8, step8, q0m3, step3, q0m5, step5);
+
+                                        kernel(currentSize, exponent, twoPGpu, (GpuUInt128)kStart, last, 0UL,
+                                                ra, orderBuffer.View, smallCyclesView, primeViews.LastOne, primeViews.LastSeven, primeViews.LastOnePow2, primeViews.LastSevenPow2);
+
+                                        accelerator.Synchronize();
+                                        orderBuffer.View.CopyToCPU(ref MemoryMarshal.GetReference(orders), currentSize);
+                                        if (!Volatile.Read(ref isPrime))
+                                        {
+                                                break;
+                                        }
+
+                                        for (int i = 0; i < currentSize; i++)
+                                        {
+                                                if (orders[i] != 0UL)
+                                                {
+                                                        Volatile.Write(ref isPrime, false);
+                                                        break;
+                                                }
+                                        }
+
+                                        kStart += batchSize128;
+                                }
                         }
                 }
                 finally
                 {
                         ArrayPool<ulong>.Shared.Return(orderArray);
-			orderBuffer.Dispose();
-			gpuLease.Dispose();
-		}
-	}
+                        orderBuffer.Dispose();
+                        gpuLease.Dispose();
+                }
+
+                divisorsExhausted = true;
+    }
 }


### PR DESCRIPTION
## Summary
- Added a residueDivisorSets parameter to `MersenneNumberTester`, introduced a shared `DivideRoundUp` helper, and segmented the residue scan so the overall limit is distributed across multiple divisor-set cycles before invoking the CPU or GPU testers.
- Refactored the CPU and GPU residue testers to walk offset-based divisor segments with guards for empty batches, keeping residue updates and early exits consistent with the new segmentation strategy.
- Wired the CLI to reuse `--divisor-cycles-limit` for residue mode, propagated the new constructor argument in program tests, and updated unit tests to exercise the revised `Scan` signatures.
- Added divisor-mode coverage to ensure detailed checks flip to true whenever a factor is identified through the GPU divisor scan.

## Testing
- `dotnet test EvenPerfectBitScanner.Tests/EvenPerfectBitScanner.Tests.csproj --filter "FullyQualifiedName~ProgramTests"`


------
https://chatgpt.com/codex/tasks/task_e_68cad972af6883258107370804b1489b