### PR TITLE
Allow residue GPU scanning to cover UInt128 divisors

### DIFF
--- a/PerfectNumbers.Core.Tests/MersenneNumberResidueCpuTesterTests.cs
+++ b/PerfectNumbers.Core.Tests/MersenneNumberResidueCpuTesterTests.cs
@@ -30,7 +30,7 @@ public class MersenneNumberResidueCpuTesterTests
                 (UInt128)exponent << 1,
                 LastDigitIsSeven(exponent),
                 (UInt128)maxK,
-                1UL,
+                UInt128.One,
                 (UInt128)maxK,
                 ref isPrime,
                 ref exhausted);

--- a/PerfectNumbers.Core.Tests/MersenneNumberResidueGpuTesterTests.cs
+++ b/PerfectNumbers.Core.Tests/MersenneNumberResidueGpuTesterTests.cs
@@ -33,7 +33,7 @@ public class MersenneNumberResidueGpuTesterTests
                 (UInt128)exponent << 1,
                 LastDigitIsSeven(exponent),
                 (UInt128)maxK,
-                1UL,
+                UInt128.One,
                 (UInt128)maxK,
                 ref isPrime,
                 ref exhausted);

--- a/PerfectNumbers.Core/Cpu/MersenneNumberResidueCpuTester.cs
+++ b/PerfectNumbers.Core/Cpu/MersenneNumberResidueCpuTester.cs
@@ -10,12 +10,12 @@ public class MersenneNumberResidueCpuTester
             UInt128 twoP,
             bool lastIsSeven,
             UInt128 perSetLimit,
-            ulong setCount,
+            UInt128 setCount,
             UInt128 overallLimit,
             ref bool isPrime,
             ref bool divisorsExhausted)
     {
-            if (setCount == 0UL || perSetLimit == UInt128.Zero || overallLimit == UInt128.Zero)
+            if (setCount == UInt128.Zero || perSetLimit == UInt128.Zero || overallLimit == UInt128.Zero)
             {
                     return;
             }
@@ -52,9 +52,9 @@ public class MersenneNumberResidueCpuTester
 
                 ModResidueTracker tracker = _mersenneResidueTracker!;
                 UInt128 limitInclusive = overallLimit + UInt128.One;
-                for (ulong setIndex = 0; setIndex < setCount && Volatile.Read(ref isPrime); setIndex++)
+                for (UInt128 setIndex = UInt128.Zero; setIndex < setCount && Volatile.Read(ref isPrime); setIndex++)
                 {
-                        UInt128 setOffset = perSetLimit * (UInt128)setIndex;
+                        UInt128 setOffset = perSetLimit * setIndex;
                         UInt128 k = setOffset + UInt128.One;
                         if (k >= limitInclusive)
                         {

--- a/PerfectNumbers.Core/Gpu/MersenneNumberResidueGpuTester.cs
+++ b/PerfectNumbers.Core/Gpu/MersenneNumberResidueGpuTester.cs
@@ -12,20 +12,20 @@ public class MersenneNumberResidueGpuTester(bool useGpuOrder)
 	// via GpuKernelPool to avoid host round-trips.
 
 	// GPU residue variant: check 2^p % q == 1 for q = 2*p*k + 1.
-	public void Scan(
-			ulong exponent,
-			UInt128 twoP,
-			bool lastIsSeven,
-			UInt128 perSetLimit,
-			ulong setCount,
-			UInt128 overallLimit,
-			ref bool isPrime,
-			ref bool divisorsExhausted)
-	{
-		if (setCount == 0UL || perSetLimit == UInt128.Zero || overallLimit == UInt128.Zero)
-		{
-			return;
-		}
+        public void Scan(
+                        ulong exponent,
+                        UInt128 twoP,
+                        bool lastIsSeven,
+                        UInt128 perSetLimit,
+                        UInt128 setCount,
+                        UInt128 overallLimit,
+                        ref bool isPrime,
+                        ref bool divisorsExhausted)
+        {
+                if (setCount == UInt128.Zero || perSetLimit == UInt128.Zero || overallLimit == UInt128.Zero)
+                {
+                        return;
+                }
 
 		var gpuLease = GpuKernelPool.GetKernel(_useGpuOrder);
 		var accelerator = gpuLease.Accelerator;
@@ -48,9 +48,9 @@ public class MersenneNumberResidueGpuTester(bool useGpuOrder)
 		Span<ulong> orders = orderArray.AsSpan(0, batchSize);
 		try
 		{
-			for (ulong setIndex = 0; setIndex < setCount && Volatile.Read(ref isPrime); setIndex++)
-			{
-				UInt128 setOffset = perSetLimit * (UInt128)setIndex;
+                for (UInt128 setIndex = UInt128.Zero; setIndex < setCount && Volatile.Read(ref isPrime); setIndex++)
+                {
+                        UInt128 setOffset = perSetLimit * setIndex;
 				UInt128 setStart = setOffset + UInt128.One;
 				if (setStart >= limitInclusive)
 				{


### PR DESCRIPTION
## Summary
- allow the CLI to accept UInt128 values for residue scan limits and propagate them when residue scanning is enabled
- update the residue CPU/GPU scanners and tester orchestration to iterate over UInt128 set counts
- refresh the residue unit tests and option help text to reflect the wider divisor range support

## Testing
- dotnet build EvenPerfectScanner.sln
- dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName~MersenneNumberResidueCpuTesterTests"
- dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName~MersenneNumberResidueGpuTesterTests"
- dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName~MersenneResidueModeTests"


------
https://chatgpt.com/codex/tasks/task_e_68cdf68aa7ec83258fdd93472e4bd087