### PR TITLE
Align residue GPU divisor limit with divisor mode

### DIFF
--- a/EvenPerfectBitScanner.Tests/ProgramTests.cs
+++ b/EvenPerfectBitScanner.Tests/ProgramTests.cs
@@ -38,6 +38,28 @@ public class ProgramTests
         Program.TransformPAdd(7UL, ref remainder).Should().Be(11UL);
     }
 
+    [Theory]
+    [InlineData(false, false, false, 5UL, 1024UL, 5UL)]
+    [InlineData(true, false, false, 5UL, 1024UL, 5UL)]
+    [InlineData(true, true, true, 7UL, 1024UL, 7UL)]
+    [InlineData(true, false, true, 5UL, 1024UL, 1024UL)]
+    [InlineData(true, true, false, 5UL, 1024UL, 5UL)]
+    public void ResolveResidueMaxK_applies_expected_rules(
+        bool useResidue,
+        bool residueMaxExplicit,
+        bool divisorLimitExplicit,
+        ulong residueMaxK,
+        ulong divisorLimit,
+        ulong expected)
+    {
+        Program.ResolveResidueMaxK(
+                useResidue,
+                residueMaxExplicit,
+                divisorLimitExplicit,
+                residueMaxK,
+                divisorLimit).Should().Be((UInt128)expected);
+    }
+
     [Fact]
     public void TransformPBit_appends_one_bit_and_skips_to_candidate()
     {

--- a/PerfectNumbers.Core/MersenneNumberTester.cs
+++ b/PerfectNumbers.Core/MersenneNumberTester.cs
@@ -268,6 +268,20 @@ public sealed class MersenneNumberTester(
             }
 
             UInt128 requestedSets = _residueDivisorSetCount;
+            if (_useGpuScan)
+            {
+                UInt128 maxUsefulSets = DivideRoundUp(totalLimit, (UInt128)GpuConstants.ScanBatchSize);
+                if (maxUsefulSets == UInt128.Zero)
+                {
+                    maxUsefulSets = UInt128.One;
+                }
+
+                if (requestedSets == UInt128.Zero || requestedSets > maxUsefulSets)
+                {
+                    requestedSets = maxUsefulSets;
+                }
+            }
+
             if (requestedSets == UInt128.Zero)
             {
                 requestedSets = UInt128.One;


### PR DESCRIPTION
## Summary
- honor `--divisor-cycles-limit` when residue scanning is active without overriding an explicit `--residue-max-k`
- bound residue GPU batch configuration so large divisor limits map to efficient set counts
- add coverage for the new residue limit resolver helper

## Testing
- dotnet test EvenPerfectBitScanner.Tests/EvenPerfectBitScanner.Tests.csproj -c Debug --filter "Category=Fast"
- timeout 120s dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName~MersenneResidueModeTests"

------
https://chatgpt.com/codex/tasks/task_e_68ce05d51e108325a3fa8cba9443a93f