### PR TITLE
Fix residue kernel modulus reduction for residue Mersenne scan

### DIFF
--- a/PerfectNumbers.Core.Tests/MersenneNumberTester/MersenneResidueModeTests.cs
+++ b/PerfectNumbers.Core.Tests/MersenneNumberTester/MersenneResidueModeTests.cs
@@ -19,5 +19,12 @@ public class MersenneResidueModeTests
         var tester = new MersenneNumberTester(useResidue: true, useIncremental: true, maxK: 1_000UL);
         tester.IsMersennePrime(31UL).Should().BeTrue();
     }
+
+    [Fact]
+    public void IsMersennePrime_residue_mode_accepts_prime_exponent_when_scanning_multiple_batches()
+    {
+        var tester = new MersenneNumberTester(useResidue: true, useIncremental: true, maxK: 2_100_000UL);
+        tester.IsMersennePrime(31UL).Should().BeTrue();
+    }
 }
 

--- a/PerfectNumbers.Core/Gpu/GpuKernelPool.cs
+++ b/PerfectNumbers.Core/Gpu/GpuKernelPool.cs
@@ -312,14 +312,19 @@ public ref struct GpuKernelLease(IDisposable limiter, GpuContextLease gpu, Kerne
             }
             else
             {
-                ulong r3 = ra.Q0M3 + (ra.Step3 * (idx % 3UL)); r3 -= (r3 >= 3UL) ? 3UL : 0UL;
+                ulong r3 = ra.Q0M3 + (ra.Step3 * (idx % 3UL));
+                if (r3 >= 6UL) r3 -= 6UL;
+                if (r3 >= 3UL) r3 -= 3UL;
                 if (r3 == 0UL)
                 {
                     shouldCheck = false;
                 }
                 else
                 {
-                    ulong r5 = ra.Q0M5 + (ra.Step5 * (idx % 5UL)); if (r5 >= 5UL) r5 -= 5UL;
+                    ulong r5 = ra.Q0M5 + (ra.Step5 * (idx % 5UL));
+                    if (r5 >= 15UL) r5 -= 15UL;
+                    if (r5 >= 10UL) r5 -= 10UL;
+                    if (r5 >= 5UL) r5 -= 5UL;
                     if (r5 == 0UL)
                     {
                         shouldCheck = false;
@@ -434,19 +439,24 @@ public ref struct GpuKernelLease(IDisposable limiter, GpuContextLease gpu, Kerne
 			}
 			else
 			{
-				ulong r3 = ra.Q0M3 + (ra.Step3 * (idx % 3UL)); r3 -= (r3 >= 3UL) ? 3UL : 0UL;
-				if (r3 == 0UL)
-				{
-					shouldCheck = false;
-				}
-				else
-				{
-					ulong r5 = ra.Q0M5 + (ra.Step5 * (idx % 5UL)); if (r5 >= 5UL) r5 -= 5UL;
-					if (r5 == 0UL)
-					{
-						shouldCheck = false;
-					}
-				}
+                                ulong r3 = ra.Q0M3 + (ra.Step3 * (idx % 3UL));
+                                if (r3 >= 6UL) r3 -= 6UL;
+                                if (r3 >= 3UL) r3 -= 3UL;
+                                if (r3 == 0UL)
+                                {
+                                        shouldCheck = false;
+                                }
+                                else
+                                {
+                                        ulong r5 = ra.Q0M5 + (ra.Step5 * (idx % 5UL));
+                                        if (r5 >= 15UL) r5 -= 15UL;
+                                        if (r5 >= 10UL) r5 -= 10UL;
+                                        if (r5 >= 5UL) r5 -= 5UL;
+                                        if (r5 == 0UL)
+                                        {
+                                                shouldCheck = false;
+                                        }
+                                }
 			}
 		}
 		if (!shouldCheck)
@@ -509,19 +519,24 @@ public ref struct GpuKernelLease(IDisposable limiter, GpuContextLease gpu, Kerne
 			}
 			else
 			{
-				ulong r3 = ra.Q0M3 + (ra.Step3 * (idx % 3UL)); r3 -= (r3 >= 3UL) ? 3UL : 0UL;
-				if (r3 == 0UL)
-				{
-					shouldCheck = false;
-				}
-				else
-				{
-					ulong r5 = ra.Q0M5 + (ra.Step5 * (idx % 5UL)); if (r5 >= 5UL) r5 -= 5UL;
-					if (r5 == 0UL)
-					{
-						shouldCheck = false;
-					}
-				}
+                                ulong r3 = ra.Q0M3 + (ra.Step3 * (idx % 3UL));
+                                if (r3 >= 6UL) r3 -= 6UL;
+                                if (r3 >= 3UL) r3 -= 3UL;
+                                if (r3 == 0UL)
+                                {
+                                        shouldCheck = false;
+                                }
+                                else
+                                {
+                                        ulong r5 = ra.Q0M5 + (ra.Step5 * (idx % 5UL));
+                                        if (r5 >= 15UL) r5 -= 15UL;
+                                        if (r5 >= 10UL) r5 -= 10UL;
+                                        if (r5 >= 5UL) r5 -= 5UL;
+                                        if (r5 == 0UL)
+                                        {
+                                                shouldCheck = false;
+                                        }
+                                }
 			}
 		}
 		if (!shouldCheck)


### PR DESCRIPTION
## Summary
- correct the GPU residue scanning kernels to fully reduce mod 3 and mod 5 residues before filtering
- update both pow2-mod and order kernels so composite remainders are rejected consistently
- add a regression test verifying residue mode accepts known primes when scanning across multiple batches

## Testing
- dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName~MersenneResidueModeTests"

------
https://chatgpt.com/codex/tasks/task_e_68ce0d8044288325a5c9eaab08246e35