### PR TITLE
Prevent residue filter from skipping primes after reaching maxP

### DIFF
--- a/EvenPerfectBitScanner/Program.cs
+++ b/EvenPerfectBitScanner/Program.cs
@@ -643,9 +643,17 @@ internal static class Program
 					}
 					else
 					{
-						for (j = 0; j < count && !Volatile.Read(ref _limitReached); j++)
+						bool reachedMax = false;
+
+						for (j = 0; j < count; j++)
 						{
 							p = buffer[j];
+
+							if (Volatile.Read(ref _limitReached) && p > maxP)
+							{
+								break;
+							}
+
 							if (useFilter && !filter.Contains(p))
 							{
 								continue;
@@ -653,11 +661,17 @@ internal static class Program
 
 							passedAllTests = IsEvenPerfectCandidate(p, divisorCyclesSearchLimit, out searchedMersenne, out detailedCheck);
 							PrintResult(p, searchedMersenne, detailedCheck, passedAllTests);
+
 							if (p == maxP)
 							{
-								Volatile.Write(ref _limitReached, true);
-								break;
+								reachedMax = true;
 							}
+						}
+
+						if (reachedMax)
+						{
+							Volatile.Write(ref _limitReached, true);
+							break;
 						}
 					}
 				}


### PR DESCRIPTION
## Summary
- allow residue filter runs to finish processing buffered exponents before signalling completion
- stop the scan once the maximum filtered exponent has been handled without skipping remaining entries

## Testing
- dotnet test EvenPerfectScanner.sln -c Release --filter "FullyQualifiedName~ProgramTests"


------
https://chatgpt.com/codex/tasks/task_e_68ce143a08cc8325840cf08aaeca0f9e