### PR TITLE
Fix GPU residue false positives for Mersenne primes

### DIFF
--- a/PerfectNumbers.Core.Tests/MersenneNumberResidueGpuTesterTests.cs
+++ b/PerfectNumbers.Core.Tests/MersenneNumberResidueGpuTesterTests.cs
@@ -21,7 +21,55 @@ public class MersenneNumberResidueGpuTesterTests
         RunCase(tester, 29UL, 37UL, expectedPrime: false);
         RunCase(tester, 31UL, 1_000UL, expectedPrime: true);
         RunCase(tester, 89UL, 1_001UL, expectedPrime: true);
+        RunCase(tester, 107UL, 1_001UL, expectedPrime: true);
         RunCase(tester, 127UL, 1_001UL, expectedPrime: true);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    [Trait("Category", "Fast")]
+    public void Scan_handles_multiple_sets_without_false_positives(bool useGpuOrder)
+    {
+        var tester = new MersenneNumberResidueGpuTester(useGpuOrder);
+
+        bool isPrime = true;
+        bool exhausted = false;
+        UInt128 perSetLimit = 1_666_667UL;
+        UInt128 setCount = 3UL;
+        UInt128 overallLimit = 5_000_000UL;
+
+        tester.Scan(
+            127UL,
+            (UInt128)127UL << 1,
+            LastDigitIsSeven(127UL),
+            perSetLimit,
+            setCount,
+            overallLimit,
+            ref isPrime,
+            ref exhausted);
+
+        isPrime.Should().BeTrue();
+        exhausted.Should().BeTrue();
+
+        isPrime = true;
+        exhausted = false;
+        perSetLimit = 20_000_000UL;
+        setCount = 5UL;
+        overallLimit = 100_000_000UL;
+
+        tester.Scan(
+            107UL,
+            (UInt128)107UL << 1,
+            LastDigitIsSeven(107UL),
+            perSetLimit,
+            setCount,
+            overallLimit,
+            ref isPrime,
+            ref exhausted);
+
+        isPrime.Should().BeTrue();
+        exhausted.Should().BeTrue();
     }
 
     private static void RunCase(MersenneNumberResidueGpuTester tester, ulong exponent, ulong maxK, bool expectedPrime)

--- a/PerfectNumbers.Core/Gpu/GpuKernelPool.cs
+++ b/PerfectNumbers.Core/Gpu/GpuKernelPool.cs
@@ -195,12 +195,12 @@ public ref struct GpuKernelLease(IDisposable limiter, GpuContextLease gpu, Kerne
         GpuUInt128 q = twoP.Mul64(k) + GpuUInt128.One;
         
         // Small-cycles in-kernel early rejection from device table
-        if (q.High == 0UL && q.Low <= (ulong)(smallCycles.Length - 1))
+        if (q.High == 0UL && q.Low < (ulong)smallCycles.Length)
         {
             uint cyc = smallCycles[(int)q.Low];
-            if (cyc != 0U && (exponent % cyc) == 0UL)
+            if (cyc != 0U && (exponent % cyc) != 0UL)
             {
-                orders[index] = exponent;
+                orders[index] = 0UL;
                 return;
             }
         }
@@ -340,12 +340,12 @@ public ref struct GpuKernelLease(IDisposable limiter, GpuContextLease gpu, Kerne
 
         GpuUInt128 k = kStart + (GpuUInt128)idx;
         GpuUInt128 q = twoP.Mul64(k) + GpuUInt128.One;
-        if (q.High == 0UL && q.Low <= (ulong)(smallCycles.Length - 1))
+        if (q.High == 0UL && q.Low < (ulong)smallCycles.Length)
         {
             uint cyc = smallCycles[(int)q.Low];
-            if (cyc != 0U && (exponent % cyc) == 0UL)
+            if (cyc != 0U && (exponent % cyc) != 0UL)
             {
-                orders[index] = exponent;
+                orders[index] = 0UL;
                 return;
             }
         }
@@ -468,10 +468,10 @@ public ref struct GpuKernelLease(IDisposable limiter, GpuContextLease gpu, Kerne
         GpuUInt128 q = twoP.Mul64(k) + GpuUInt128.One;
 
         // Small-cycles in-kernel early rejection from device table
-        if (q.High == 0UL && q.Low <= (ulong)(smallCycles.Length - 1))
+        if (q.High == 0UL && q.Low < (ulong)smallCycles.Length)
         {
             uint cyc = smallCycles[(int)q.Low];
-            if (cyc != 0U && (exponent % (ulong)cyc) == 0UL)
+            if (cyc != 0U && (exponent % (ulong)cyc) != 0UL)
             {
                 return;
             }
@@ -547,10 +547,10 @@ public ref struct GpuKernelLease(IDisposable limiter, GpuContextLease gpu, Kerne
         GpuUInt128 k = kStart + (GpuUInt128)idx;
         GpuUInt128 q = twoP.Mul64(k) + GpuUInt128.One;
         // Small-cycles in-kernel early rejection from device table
-        if (q.High == 0UL && q.Low <= (ulong)(smallCycles.Length - 1))
+        if (q.High == 0UL && q.Low < (ulong)smallCycles.Length)
         {
             uint cyc = smallCycles[(int)q.Low];
-            if (cyc != 0U && (exponent % (ulong)cyc) == 0UL)
+            if (cyc != 0U && (exponent % (ulong)cyc) != 0UL)
             {
                 return;
             }


### PR DESCRIPTION
## Summary
* prevent GPU small-cycle shortcuts from marking Mersenne exponents composite without verifying that the divisor actually satisfies 2^p ≡ 1 (mod q) by reusing the cycle table purely as an early rejection hint across every residue kernel.【F:PerfectNumbers.Core/Gpu/GpuKernelPool.cs†L188-L206】【F:PerfectNumbers.Core/Gpu/GpuKernelPool.cs†L341-L355】【F:PerfectNumbers.Core/Gpu/GpuKernelPool.cs†L467-L476】【F:PerfectNumbers.Core/Gpu/GpuKernelPool.cs†L547-L555】
* expand GPU residue unit coverage to include the 107/127 primes and multi-set scan scenarios so regressions surface quickly.【F:PerfectNumbers.Core.Tests/MersenneNumberResidueGpuTesterTests.cs†L20-L73】
* add a Program-level regression test to ensure the default residue limits still accept known primes when running on the GPU.【F:EvenPerfectBitScanner.Tests/ProgramTests.cs†L362-L398】

## Testing
* dotnet test PerfectNumbers.Core.Tests --filter "FullyQualifiedName~MersenneNumberResidueGpuTesterTests" -c Release【0d9380†L1-L2】
* dotnet test EvenPerfectBitScanner.Tests --filter "Residue_mode_with_default_limits_accepts_large_known_primes" -c Release【c43df6†L1-L3】

------
https://chatgpt.com/codex/tasks/task_e_68ce4a671584832584d2233e3fd709cb