### PR TITLE
Expand residue thread coverage tests

### DIFF
--- a/PerfectNumbers.Core.Tests/MersenneNumberResidueCpuTesterTests.cs
+++ b/PerfectNumbers.Core.Tests/MersenneNumberResidueCpuTesterTests.cs
@@ -33,19 +33,52 @@ public class MersenneNumberResidueCpuTesterTests
         }
     }
 
+    [Theory]
+    [InlineData(31UL)]
+    [Trait("Category", "Fast")]
+    public void Scan_matches_cli_residue_configuration_for_primes(ulong exponent)
+    {
+        RunCase(new MersenneNumberResidueCpuTester(), exponent, 32UL, expectedPrime: true);
+    }
+
+    [Theory]
+    [InlineData(31UL, 1_024UL, 1UL)]
+    [InlineData(31UL, 512UL, 2UL)]
+    [InlineData(31UL, 256UL, 4UL)]
+    [InlineData(127UL, 256UL, 1UL)]
+    [InlineData(127UL, 128UL, 2UL)]
+    [InlineData(127UL, 64UL, 4UL)]
+    [Trait("Category", "Fast")]
+    public void Scan_handles_multiple_residue_sets_for_known_primes(ulong exponent, ulong perSetLimit, ulong setCount)
+    {
+        ulong overallLimit = perSetLimit * setCount;
+        RunCase(new MersenneNumberResidueCpuTester(), exponent, perSetLimit, setCount, overallLimit, expectedPrime: true);
+    }
+
     private static void RunCase(MersenneNumberResidueCpuTester tester, ulong exponent, ulong maxK, bool expectedPrime)
+    {
+        RunCase(tester, exponent, maxK, 1UL, maxK, expectedPrime);
+    }
+
+    private static void RunCase(
+        MersenneNumberResidueCpuTester tester,
+        ulong exponent,
+        ulong perSetLimit,
+        ulong setCount,
+        ulong overallLimit,
+        bool expectedPrime)
     {
         bool isPrime = true;
         bool exhausted = false;
         tester.Scan(
-                exponent,
-                (UInt128)exponent << 1,
-                LastDigitIsSeven(exponent),
-                (UInt128)maxK,
-                UInt128.One,
-                (UInt128)maxK,
-                ref isPrime,
-                ref exhausted);
+            exponent,
+            (UInt128)exponent << 1,
+            LastDigitIsSeven(exponent),
+            (UInt128)perSetLimit,
+            (UInt128)setCount,
+            (UInt128)overallLimit,
+            ref isPrime,
+            ref exhausted);
         isPrime.Should().Be(expectedPrime);
         exhausted.Should().BeTrue();
     }

--- a/PerfectNumbers.Core.Tests/MersenneNumberResidueIntegrationTests.cs
+++ b/PerfectNumbers.Core.Tests/MersenneNumberResidueIntegrationTests.cs
@@ -1,0 +1,172 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using PerfectNumbers.Core;
+using PerfectNumbers.Core.Gpu;
+using Xunit;
+using UInt128 = System.UInt128;
+
+namespace PerfectNumbers.Core.Tests;
+
+public class MersenneNumberResidueIntegrationTests
+{
+    public static IEnumerable<object[]> ResidueThreadCounts()
+    {
+        yield return new object[] { 1 };
+        yield return new object[] { 2 };
+        yield return new object[] { 4 };
+    }
+
+    [Theory]
+    [MemberData(nameof(ResidueThreadCounts))]
+    [Trait("Category", "Fast")]
+    public void Residue_gpu_mode_matches_cli_configuration_for_known_primes(int threadCount)
+    {
+        ulong[] exponents = MersennePrimeTestData.Exponents;
+        ulong[][] partitions = PartitionExponents(exponents, threadCount);
+        var results = new ConcurrentDictionary<ulong, (bool IsPrime, bool Exhausted)>();
+        UInt128 residueSetCount = (UInt128)PerfectNumberConstants.ExtraDivisorCycleSearchLimit;
+
+        try
+        {
+            Task[] tasks = partitions.Select(partition => Task.Run(() =>
+            {
+                if (partition.Length == 0)
+                {
+                    return;
+                }
+
+                var tester = new MersenneNumberTester(
+                    useIncremental: false,
+                    useOrderCache: false,
+                    kernelType: GpuKernelType.Pow2Mod,
+                    useModuloWorkaround: false,
+                    useOrder: false,
+                    useGpuLucas: false,
+                    useGpuScan: true,
+                    useGpuOrder: true,
+                    useResidue: true,
+                    maxK: (UInt128)1_024UL,
+                    residueDivisorSets: residueSetCount);
+
+                foreach (ulong exponent in partition)
+                {
+                    bool isPrime = tester.IsMersennePrime(exponent, out bool divisorsExhausted);
+                    results[exponent] = (isPrime, divisorsExhausted);
+                }
+            })).ToArray();
+
+            Task.WaitAll(tasks);
+        }
+        finally
+        {
+            GpuContextPool.DisposeAll();
+        }
+
+        results.Keys.Should().BeEquivalentTo(exponents);
+        foreach (ulong exponent in exponents)
+        {
+            results[exponent].Should().Be((true, true));
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ResidueThreadCounts))]
+    [Trait("Category", "Fast")]
+    public void Residue_cpu_mode_matches_cli_configuration_for_known_primes(int threadCount)
+    {
+        ulong[] exponents = MersennePrimeTestData.Exponents;
+        ulong[][] partitions = PartitionExponents(exponents, threadCount);
+        var results = new ConcurrentDictionary<ulong, (bool IsPrime, bool Exhausted)>();
+        UInt128 residueSetCount = (UInt128)PerfectNumberConstants.ExtraDivisorCycleSearchLimit;
+
+        Task[] tasks = partitions.Select(partition => Task.Run(() =>
+        {
+            if (partition.Length == 0)
+            {
+                return;
+            }
+
+            var tester = new MersenneNumberTester(
+                useIncremental: false,
+                useOrderCache: false,
+                kernelType: GpuKernelType.Pow2Mod,
+                useModuloWorkaround: false,
+                useOrder: false,
+                useGpuLucas: false,
+                useGpuScan: false,
+                useGpuOrder: false,
+                useResidue: true,
+                maxK: (UInt128)1_024UL,
+                residueDivisorSets: residueSetCount);
+
+            foreach (ulong exponent in partition)
+            {
+                bool isPrime = tester.IsMersennePrime(exponent, out bool divisorsExhausted);
+                results[exponent] = (isPrime, divisorsExhausted);
+            }
+        })).ToArray();
+
+        Task.WaitAll(tasks);
+
+        results.Keys.Should().BeEquivalentTo(exponents);
+        foreach (ulong exponent in exponents)
+        {
+            results[exponent].Should().Be((true, true));
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Fast")]
+    public void Residue_cpu_mode_respects_filter_configuration()
+    {
+        var filter = new HashSet<ulong>(MersennePrimeTestData.Exponents);
+        ulong[] candidates = [31UL, 37UL, 73UL];
+
+        var tester = new MersenneNumberTester(
+            useIncremental: false,
+            useOrderCache: false,
+            kernelType: GpuKernelType.Pow2Mod,
+            useModuloWorkaround: false,
+            useOrder: false,
+            useGpuLucas: false,
+            useGpuScan: false,
+            useGpuOrder: false,
+            useResidue: true,
+            maxK: (UInt128)32UL,
+            residueDivisorSets: (UInt128)4UL);
+
+        List<ulong> processed = new();
+        List<ulong> skipped = new();
+
+        filter.Count.Should().Be(MersennePrimeTestData.Exponents.Length);
+
+        foreach (ulong exponent in candidates)
+        {
+            if (!filter.Contains(exponent))
+            {
+                skipped.Add(exponent);
+                continue;
+            }
+
+            bool isPrime = tester.IsMersennePrime(exponent, out bool divisorsExhausted);
+            isPrime.Should().BeTrue();
+            divisorsExhausted.Should().BeTrue();
+            processed.Add(exponent);
+        }
+
+        processed.Should().ContainSingle().Which.Should().Be(31UL);
+        skipped.Should().BeEquivalentTo(new[] { 37UL, 73UL });
+    }
+
+    private static ulong[][] PartitionExponents(ulong[] exponents, int threadCount)
+    {
+        return Enumerable
+            .Range(0, threadCount)
+            .Select(partition => exponents.Where((_, index) => index % threadCount == partition).ToArray())
+            .ToArray();
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend CPU and GPU residue unit tests to cover varying residue set counts, including high-set GPU scenarios that mirror CLI defaults
- add integration coverage that runs the complete Mersenne prime list across multiple thread counts for both GPU and CPU residue paths, using the CLI residue set configuration

## Testing
- dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName~MersenneNumberResidueCpuTesterTests"
- timeout 120s dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName=PerfectNumbers.Core.Tests.MersenneNumberResidueGpuTesterTests.Scan_handles_multiple_residue_sets_for_known_primes"
- timeout 120s dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName=PerfectNumbers.Core.Tests.MersenneNumberResidueIntegrationTests.Residue_gpu_mode_matches_cli_configuration_for_known_primes"
- timeout 120s dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName=PerfectNumbers.Core.Tests.MersenneNumberResidueIntegrationTests.Residue_cpu_mode_matches_cli_configuration_for_known_primes"

------
https://chatgpt.com/codex/tasks/task_e_68ce6bd18d208325afaf6fad18c08a63