### PR TITLE
Serialize GPU leases with per-accelerator locks

### DIFF
--- a/PerfectNumbers.Core/Gpu/GpuContextPool.cs
+++ b/PerfectNumbers.Core/Gpu/GpuContextPool.cs
@@ -10,13 +10,14 @@ public static class GpuContextPool
 	// Default device preference for generic GPU kernels (prime scans, NTT, etc.)
 	public static bool ForceCpu { get; set; } = false;
 
-	internal sealed class PooledContext
-	{
-		private bool disposed;
+        internal sealed class PooledContext
+        {
+                private bool disposed;
 
-		public Context Context { get; }
-		public Accelerator Accelerator { get; }
-		public bool IsCpu { get; }
+                public Context Context { get; }
+                public Accelerator Accelerator { get; }
+                public bool IsCpu { get; }
+                public object ExecutionLock { get; } = new();
 
 		public PooledContext(bool preferCpu)
 		{
@@ -126,24 +127,26 @@ public static class GpuContextPool
     public struct GpuContextLease : IDisposable
     {
         private readonly PooledContext _ctx;
-		private bool disposed;
+                private bool disposed;
 
-		internal GpuContextLease(PooledContext ctx, object kernelInitLock)
+                internal GpuContextLease(PooledContext ctx, object kernelInitLock)
         {
             _ctx = ctx;
-			KernelInitLock = kernelInitLock;
-		}
+                        KernelInitLock = kernelInitLock;
+                }
 
         public Context Context => _ctx.Context;
 
         public Accelerator Accelerator => _ctx.Accelerator;
 
-		public object KernelInitLock { get; }
+                public object KernelInitLock { get; }
+
+                public object ExecutionLock => _ctx.ExecutionLock;
 
 
-		public void Dispose()
-		{
-			if (disposed)
+                public void Dispose()
+                {
+                        if (disposed)
 			{
 				return;
 			}

--- a/PerfectNumbers.Core/Gpu/MersenneNumberOrderGpuTester.cs
+++ b/PerfectNumbers.Core/Gpu/MersenneNumberOrderGpuTester.cs
@@ -10,7 +10,9 @@ public class MersenneNumberOrderGpuTester(GpuKernelType kernelType, bool useGpuO
         public void Scan(ulong exponent, UInt128 twoP, bool lastIsSeven, UInt128 maxK, ref bool isPrime)
         {
                 var gpuLease = GpuKernelPool.GetKernel(_useGpuOrder);
+                var execution = gpuLease.EnterExecutionScope();
                 var accelerator = gpuLease.Accelerator;
+                var stream = gpuLease.Stream;
                 int batchSize = GpuConstants.ScanBatchSize; // large batch improves GPU occupancy and avoids TDR
                 UInt128 kStart = UInt128.One;
                 ulong divMul = (ulong)((((UInt128)1 << 64) - UInt128.One) / exponent) + 1UL;
@@ -23,45 +25,51 @@ public class MersenneNumberOrderGpuTester(GpuKernelType kernelType, bool useGpuO
         };
 
                 var foundBuffer = accelerator.Allocate1D<int>(1);
-                UInt128 remaining;
-                int currentSize;
-                int found = 0;
-                while (kStart <= maxK && Volatile.Read(ref isPrime))
+                try
                 {
-                        remaining = maxK - kStart + 1UL;
-                        currentSize = remaining > (UInt128)batchSize ? batchSize : (int)remaining;
-                        foundBuffer.MemSetToZero();
-                        // Precompute residue automaton bases for this batch
-                        UInt128 q0 = twoP * kStart + 1UL;
-                        ulong q0m10 = q0.Mod10();
-                        ulong q0m8 = q0.Mod8();
-                        ulong q0m3 = q0.Mod3();
-                        ulong q0m5 = q0.Mod5();
-                        ulong step10 = ((exponent % 10UL) << 1) % 10UL;
-                        ulong step8 = ((exponent & 7UL) << 1) & 7UL;
-                        ulong step3 = ((exponent % 3UL) << 1) % 3UL;
-                        ulong step5 = ((exponent % 5UL) << 1) % 5UL;
-                        var ra = new ResidueAutomatonArgs(q0m10, step10, q0m8, step8, q0m3, step3, q0m5, step5);
-
-
-                        // Ensure device has small cycles table for early rejections in order kernels
-            var smallCyclesView = GpuKernelPool.EnsureSmallCyclesOnDevice(accelerator);
-            kernel(currentSize, exponent, (GpuUInt128)twoP, (GpuUInt128)kStart, last, divMul,
-                ra, foundBuffer.View, smallCyclesView);
-
-                        accelerator.Synchronize();
-                        foundBuffer.View.CopyToCPU(ref found, 1);
-                        if (found != 0)
+                        UInt128 remaining;
+                        int currentSize;
+                        int found = 0;
+                        while (kStart <= maxK && Volatile.Read(ref isPrime))
                         {
-                                Volatile.Write(ref isPrime, false);
-                                break;
+                                remaining = maxK - kStart + 1UL;
+                                currentSize = remaining > (UInt128)batchSize ? batchSize : (int)remaining;
+                                foundBuffer.MemSetToZero();
+                                // Precompute residue automaton bases for this batch
+                                UInt128 q0 = twoP * kStart + 1UL;
+                                ulong q0m10 = q0.Mod10();
+                                ulong q0m8 = q0.Mod8();
+                                ulong q0m3 = q0.Mod3();
+                                ulong q0m5 = q0.Mod5();
+                                ulong step10 = ((exponent % 10UL) << 1) % 10UL;
+                                ulong step8 = ((exponent & 7UL) << 1) & 7UL;
+                                ulong step3 = ((exponent % 3UL) << 1) % 3UL;
+                                ulong step5 = ((exponent % 5UL) << 1) % 5UL;
+                                var ra = new ResidueAutomatonArgs(q0m10, step10, q0m8, step8, q0m3, step3, q0m5, step5);
+
+
+                                // Ensure device has small cycles table for early rejections in order kernels
+                                var smallCyclesView = GpuKernelPool.EnsureSmallCyclesOnDevice(accelerator);
+                                kernel(stream, currentSize, exponent, (GpuUInt128)twoP, (GpuUInt128)kStart, last, divMul,
+                                        ra, foundBuffer.View, smallCyclesView);
+
+                                stream.Synchronize();
+                                foundBuffer.View.CopyToCPU(ref found, 1);
+                                if (found != 0)
+                                {
+                                        Volatile.Write(ref isPrime, false);
+                                        break;
+                                }
+
+                                kStart += (UInt128)currentSize;
                         }
-
-                        kStart += (UInt128)currentSize;
                 }
-
-                foundBuffer.Dispose();
-                gpuLease.Dispose();
+                finally
+                {
+                        foundBuffer.Dispose();
+                        execution.Dispose();
+                        gpuLease.Dispose();
+                }
 
         }
 }


### PR DESCRIPTION
## Summary
- add per-accelerator execution locks to GPU context leases and expose scoped execution scopes on kernel leases
- guard residue, incremental, and order GPU testers plus the warm-up path with execution scopes so accelerator work stays serialized across threads
- run generic GPU helpers through the execution scope to keep accelerator commands ordered

## Testing
- `dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Release --filter "FullyQualifiedName~GpuPrimeLimiterTests"`


------
https://chatgpt.com/codex/tasks/task_e_68cecb7ac2688325b231950e9d346205