### PR TITLE
Align GPU prime sieve with CPU GCD heuristic

### DIFF
--- a/PerfectNumbers.Core/PrimeTester.cs
+++ b/PerfectNumbers.Core/PrimeTester.cs
@@ -255,12 +255,15 @@ public sealed class PrimeTester(bool useInternal = false)
             return;
         }
 
-        // Early reject special gcd heuristic with floor(log2 n)
-        ulong m = 63UL - (ulong)ILGPU.Algorithms.XMath.LeadingZeroCount(n);
-        if (BinaryGcdGpu(n, m) != 1UL)
+        if ((n % 10UL) == 1UL)
         {
-            results[index] = 0;
-            return;
+            // Early reject special GCD heuristic with floor(log2 n)
+            ulong m = 63UL - (ulong)ILGPU.Algorithms.XMath.LeadingZeroCount(n);
+            if (BinaryGcdGpu(n, m) != 1UL)
+            {
+                results[index] = 0;
+                return;
+            }
         }
 
         long len = smallPrimes.Length;


### PR DESCRIPTION
## Summary
* Gate the GPU small-prime sieve’s binary GCD heuristic behind the same `n % 10 == 1` check used by the CPU path so only appropriate candidates hit the fast rejection.

## Testing
* `dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj --filter "FullyQualifiedName=PerfectNumbers.Core.Tests.PrimeTesterIsPrimeTests.IsPrimeGpu_handles_parallel_calls_for_known_primes" -c Release --logger "console;verbosity=normal"`


------
https://chatgpt.com/codex/tasks/task_e_68cee4e1e2c48325bd9eb20cc49d5580