### PR TITLE
Fix GPU residue tester iteration and add regression tests

### DIFF
--- a/PerfectNumbers.Core/Gpu/MersenneNumberResidueGpuTester.cs
+++ b/PerfectNumbers.Core/Gpu/MersenneNumberResidueGpuTester.cs
@@ -59,9 +59,9 @@ public class MersenneNumberResidueGpuTester(bool useGpuOrder)
                 Span<ulong> orders = orderArray.AsSpan(0, batchSize);
                 try
                 {
-                        for (ulong setIndex = 0; setIndex < setCount && Volatile.Read(ref isPrime); setIndex++)
+                        for (UInt128 setIndex = UInt128.Zero; setIndex < setCount && Volatile.Read(ref isPrime); setIndex++)
                         {
-                                UInt128 setOffset = checked(perSetLimit * (UInt128)setIndex);
+                                UInt128 setOffset = checked(perSetLimit * setIndex);
                                 UInt128 setStart = checked(setOffset + UInt128.One);
                                 if (setStart >= limitInclusive)
                                 {
@@ -113,7 +113,7 @@ public class MersenneNumberResidueGpuTester(bool useGpuOrder)
                                                 }
                                         }
 
-                                        kStart = checked(kStart + batchSize128);
+                                        kStart = checked(kStart + (UInt128)currentSize);
                                 }
                         }
                 }


### PR DESCRIPTION
## Summary
- iterate residue sets in the GPU residue tester using UInt128 indices and advance by the processed lane count to avoid truncation
- add regression coverage that compares GPU residue scans to the CPU implementation and exercises large residue configurations in the tester

## Testing
- dotnet test PerfectNumbers.Core.Tests -c Release --filter "FullyQualifiedName=PerfectNumbers.Core.Tests.MersenneNumberResidueGpuTesterTests.Gpu_residue_scan_matches_cpu_for_small_configurations"
- dotnet test PerfectNumbers.Core.Tests -c Release --filter "FullyQualifiedName=PerfectNumbers.Core.Tests.MersenneNumberResidueGpuTesterTests.Mersenne_tester_residue_gpu_handles_known_primes_with_many_sets"

------
https://chatgpt.com/codex/tasks/task_e_68cf1ee795c883258869871c27837a00