### PR TITLE
Implement lookup-based Mod10 for GPU compatibility

### DIFF
--- a/PerfectNumbers.Core/ULongExtensions.cs
+++ b/PerfectNumbers.Core/ULongExtensions.cs
@@ -137,8 +137,29 @@ public static class ULongExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong Mod10(this ulong value)
         {
-                ulong quotient = (ulong)(((UInt128)value * 0xCCCCCCCCCCCCCCCDUL) >> 67);
-                return value - quotient * 10UL;
+                ulong parity = value & 1UL;
+                ulong mod5 = value.Mod5();
+
+                if (parity == 0UL)
+                {
+                        return mod5 switch
+                        {
+                                0UL => 0UL,
+                                1UL => 6UL,
+                                2UL => 2UL,
+                                3UL => 8UL,
+                                _ => 4UL,
+                        };
+                }
+
+                return mod5 switch
+                {
+                        0UL => 5UL,
+                        1UL => 1UL,
+                        2UL => 7UL,
+                        3UL => 3UL,
+                        _ => 9UL,
+                };
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Summary
- compute `ulong` modulo 10 by combining parity with the existing Mod5 helper so ILGPU kernels avoid unsupported intrinsics
- reuse the existing Mod5 switch mapping already used in the mixed modulo helpers to keep GPU execution safe

## Testing
- `dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Release --filter "FullyQualifiedName~ULongExtensionsTests"`


------
https://chatgpt.com/codex/tasks/task_e_68cfc227486483258af0c062886a8271