### PR TITLE
Wire by-divisor GPU batching to scanner configuration

### DIFF
--- a/EvenPerfectBitScanner/Program.cs
+++ b/EvenPerfectBitScanner/Program.cs
@@ -495,7 +495,10 @@ internal static class Program
                 }
                 else if (useByDivisor)
                 {
-                        _byDivisorTester = new MersenneNumberDivisorByDivisorGpuTester();
+                        _byDivisorTester = new MersenneNumberDivisorByDivisorGpuTester
+                        {
+                                GpuBatchSize = scanBatchSize,
+                        };
                 }
 
 		// Load RLE blacklist (optional)


### PR DESCRIPTION
## Summary
- expose a configurable GPU batch size on the by-divisor tester and hook it up to the scanner's --gpu-scan-batch parameter
- drop the artificial divisor capacity clamp so all divisors up to the max allowed by the chosen exponent can be explored

## Testing
- dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Release --filter "FullyQualifiedName~ByDivisor_tester"

------
https://chatgpt.com/codex/tasks/task_e_68cfc55e19448325b15fc82e7028e911