### PR TITLE
Support --prime start for by-divisor scans

### DIFF
--- a/EvenPerfectBitScanner.Tests/ResultsFileNameTests.cs
+++ b/EvenPerfectBitScanner.Tests/ResultsFileNameTests.cs
@@ -19,7 +19,7 @@ public class ResultsFileNameTests
             types: new[]
             {
                 typeof(bool), typeof(int), typeof(int), typeof(global::PerfectNumbers.Core.GpuKernelType),
-                typeof(bool), typeof(bool), typeof(bool), typeof(bool), typeof(bool), typeof(bool), typeof(NttBackend), typeof(int), typeof(int), typeof(int), typeof(ulong), typeof(ModReductionMode), typeof(string), typeof(string), typeof(string)
+                typeof(bool), typeof(bool), typeof(bool), typeof(bool), typeof(bool), typeof(bool), typeof(bool), typeof(NttBackend), typeof(int), typeof(int), typeof(int), typeof(ulong), typeof(ModReductionMode), typeof(string), typeof(string), typeof(string)
             },
             modifiers: null)!;
 
@@ -31,6 +31,7 @@ public class ResultsFileNameTests
             global::PerfectNumbers.Core.GpuKernelType.Incremental,
             false,           // useLucasFlag
             false,           // useDivisorFlag
+            false,           // useByDivisorFlag
             true,            // mersenneOnGpu (unused inside name content, devices passed explicitly below)
             false,           // useOrder
             false,           // useModWorkaround


### PR DESCRIPTION
## Summary
- track the requested starting prime when running in --mersenne=bydivisor mode and skip smaller primes when building the scan state
- emit a helpful message when the provided start prime removes all candidates
- update the ResultsFileName test to include the by-divisor flag parameter in the reflective invocation

## Testing
- dotnet test EvenPerfectBitScanner.Tests/EvenPerfectBitScanner.Tests.csproj --filter "FullyQualifiedName=EvenPerfectBitScanner.Tests.ResultsFileNameTests.BuildResultsFileName_contains_reduction_and_devices"

------
https://chatgpt.com/codex/tasks/task_e_68d1c4839250832584074b45961df4f3