### PR TITLE
Fix Mod10 shortcut and restore Mod10_8_5_3Steps accuracy

### DIFF
--- a/PerfectNumbers.Core/ULongExtensions.cs
+++ b/PerfectNumbers.Core/ULongExtensions.cs
@@ -85,23 +85,27 @@ public static class ULongExtensions
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static ulong Mod10(this ulong value) => (value & 1UL) == 0UL
-			? value % 5UL switch
-			{
-				0UL => 0UL,
-				1UL => 6UL,
-				2UL => 2UL,
-				3UL => 8UL,
-				_ => 4UL,
-			}
-			: value % 5UL switch
-			{
-				0UL => 5UL,
-				1UL => 1UL,
-				2UL => 7UL,
-				3UL => 3UL,
-				_ => 9UL,
-			};
+        public static ulong Mod10(this ulong value)
+        {
+                ulong mod5 = value % 5UL;
+                return (value & 1UL) == 0UL
+                        ? mod5 switch
+                        {
+                                0UL => 0UL,
+                                1UL => 6UL,
+                                2UL => 2UL,
+                                3UL => 8UL,
+                                _ => 4UL,
+                        }
+                        : mod5 switch
+                        {
+                                0UL => 5UL,
+                                1UL => 1UL,
+                                2UL => 7UL,
+                                3UL => 3UL,
+                                _ => 9UL,
+                        };
+        }
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static ulong Mod128(this ulong value) => value & 127UL;
@@ -143,14 +147,14 @@ public static class ULongExtensions
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static void Mod10_8_5_3Steps(this ulong value, out ulong step10, out ulong step8, out ulong step5, out ulong step3)
-	{
-		value.Mod10_8_5_3(out step10, out step8, out step5, out step3);
+        public static void Mod10_8_5_3Steps(this ulong value, out ulong step10, out ulong step8, out ulong step5, out ulong step3)
+        {
+                value.Mod10_8_5_3(out step10, out step8, out step5, out step3);
 
-		step10 = (step10 << 1).Mod10();
-		step8 = (step8 << 1) & 7UL;
-		step5 = (step5 << 1) % 5UL;
-		step3 = (step3 << 1) % 3UL;
+                step10 = (step10 << 1).Mod10();
+                step8 = (step8 << 1) & 7UL;
+                step5 = (step5 << 1) % 5UL;
+                step3 = (step3 << 1) % 3UL;
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Summary
- rewrite `ULongExtensions.Mod10` to cache the modulo-5 result before branching on parity, avoiding the operator-precedence bug that computed `value % (5 switch ...)`
- keep `Mod10_8_5_3Steps` delegating to `Mod10_8_5_3` and the corrected `Mod10` so the step residues match the manual double-and-reduce formula

## Testing
- timeout 120s dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Debug --filter "FullyQualifiedName=PerfectNumbers.Core.Tests.ULongExtensionsTests.Mod10_8_5_3Steps_matches_manual_formula"


------
https://chatgpt.com/codex/tasks/task_e_68d318e1885083258ee62729c68355af