### PR TITLE
Improve by-divisor residue reuse and fix Montgomery multiplication

### DIFF
--- a/EvenPerfectBitScanner/Program.cs
+++ b/EvenPerfectBitScanner/Program.cs
@@ -813,7 +813,16 @@ internal static class Program
                         return;
                 }
 
-                states.Sort((left, right) => left.AllowedMax.CompareTo(right.AllowedMax));
+                states.Sort(static (left, right) =>
+                {
+                        int compare = left.AllowedMax.CompareTo(right.AllowedMax);
+                        if (compare != 0)
+                        {
+                                return compare;
+                        }
+
+                        return left.Prime.CompareTo(right.Prime);
+                });
 
                 int stateCount = states.Count;
                 ulong[] primeValues = new ulong[stateCount];

--- a/PerfectNumbers.Core/ULongExtensions.cs
+++ b/PerfectNumbers.Core/ULongExtensions.cs
@@ -163,18 +163,15 @@ public static class ULongExtensions
         {
                 ulong xLow = (uint)x;
                 ulong xHigh = x >> 32;
-		ulong yLow = (uint)y;
-		ulong yHigh = y >> 32;
+                ulong yLow = (uint)y;
+                ulong yHigh = y >> 32;
 
-		ulong w1 = xLow * yHigh;
-		ulong w2 = xHigh * yLow;
+                ulong w1 = xLow * yHigh;
+                ulong w2 = xHigh * yLow;
 
-		return (xHigh * yHigh) + (w1 >> 32) + (w2 >> 32) +
-			(
-				((xLow * yLow) >> 32) +
-				(uint)w1 +
-				(uint)w2
-			) >> 32;
+                ulong result = (xHigh * yHigh) + (w1 >> 32) + (w2 >> 32);
+                result += (((xLow * yLow) >> 32) + (uint)w1 + (uint)w2) >> 32;
+                return result;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Summary
- sort by-divisor prime states by allowed range and exponent to preserve progression order
- rework the GPU by-divisor session to reuse prior residues via prime deltas and add a dedicated delta kernel
- correct Montgomery high-part multiplication to avoid incorrect residues

## Testing
- dotnet build EvenPerfectScanner.sln
- dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj --filter "FullyQualifiedName~MersenneNumberDivisorGpuTesterTests"
- dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj --filter "FullyQualifiedName=PerfectNumbers.Core.Tests.MersenneNumberDivisorGpuTesterTests.ByDivisor_session_checks_divisors_across_primes"
- dotnet test EvenPerfectBitScanner.Tests/EvenPerfectBitScanner.Tests.csproj *(fails: ILGPU InternalCompilerException due to unsupported BMI2 instructions in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d362d0815483258b018589eeef5080