### PR TITLE
Optimize cycle remainder reuse in by-divisor testers

### DIFF
--- a/EvenPerfectBitScanner.Benchmarks/Pow2MontgomeryModBenchmarks.cs
+++ b/EvenPerfectBitScanner.Benchmarks/Pow2MontgomeryModBenchmarks.cs
@@ -1,9 +1,9 @@
 using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
+using System.Numerics;
 using PerfectNumbers.Core;
 using PerfectNumbers.Core.Gpu;
-using System.Numerics;
 
 namespace EvenPerfectBitScanner.Benchmarks;
 
@@ -13,8 +13,8 @@ public class Pow2MontgomeryModBenchmarks
 {
     private const int SampleCount = 256;
 
-    private readonly MersenneNumberDivisorByDivisorGpuTester.MontgomeryDivisorData[] _smallDivisors = new MersenneNumberDivisorByDivisorGpuTester.MontgomeryDivisorData[SampleCount];
-    private readonly MersenneNumberDivisorByDivisorGpuTester.MontgomeryDivisorData[] _largeDivisors = new MersenneNumberDivisorByDivisorGpuTester.MontgomeryDivisorData[SampleCount];
+    private readonly MontgomeryDivisorData[] _smallDivisors = new MontgomeryDivisorData[SampleCount];
+    private readonly MontgomeryDivisorData[] _largeDivisors = new MontgomeryDivisorData[SampleCount];
     private readonly ulong[] _smallExponents = new ulong[SampleCount];
     private readonly ulong[] _largeExponents = new ulong[SampleCount];
     private readonly ulong[] _smallCycles = new ulong[SampleCount];
@@ -184,7 +184,7 @@ public class Pow2MontgomeryModBenchmarks
         return checksum;
     }
 
-    private void GetData(out ulong[] exponents, out MersenneNumberDivisorByDivisorGpuTester.MontgomeryDivisorData[] divisors, out ulong[] cycles)
+    private void GetData(out ulong[] exponents, out MontgomeryDivisorData[] divisors, out ulong[] cycles)
     {
         if (Scale == InputScale.Small)
         {
@@ -217,14 +217,14 @@ public class Pow2MontgomeryModBenchmarks
         return (modulus, (ulong)bitLength);
     }
 
-    private static MersenneNumberDivisorByDivisorGpuTester.MontgomeryDivisorData CreateMontgomeryDivisorData(ulong modulus)
+    private static MontgomeryDivisorData CreateMontgomeryDivisorData(ulong modulus)
     {
         if (modulus <= 1UL || (modulus & 1UL) == 0UL)
         {
-            return new MersenneNumberDivisorByDivisorGpuTester.MontgomeryDivisorData(modulus, 0UL, 0UL, 0UL);
+            return new MontgomeryDivisorData(modulus, 0UL, 0UL, 0UL);
         }
 
-        return new MersenneNumberDivisorByDivisorGpuTester.MontgomeryDivisorData(
+        return new MontgomeryDivisorData(
             modulus,
             ComputeMontgomeryNPrime(modulus),
             ComputeMontgomeryResidue(1UL, modulus),
@@ -245,7 +245,7 @@ public class Pow2MontgomeryModBenchmarks
         return unchecked(0UL - inv);
     }
 
-    private static ulong Pow2MontgomeryModLeftToRight(ulong exponent, in MersenneNumberDivisorByDivisorGpuTester.MontgomeryDivisorData divisor)
+    private static ulong Pow2MontgomeryModLeftToRight(ulong exponent, in MontgomeryDivisorData divisor)
     {
         ulong modulus = divisor.Modulus;
         if (modulus <= 1UL || (modulus & 1UL) == 0UL)
@@ -277,7 +277,7 @@ public class Pow2MontgomeryModBenchmarks
         return result.MontgomeryMultiply(1UL, modulus, nPrime);
     }
 
-    private static ulong Pow2MontgomeryModBatched4(ulong exponent, in MersenneNumberDivisorByDivisorGpuTester.MontgomeryDivisorData divisor)
+    private static ulong Pow2MontgomeryModBatched4(ulong exponent, in MontgomeryDivisorData divisor)
     {
         ulong modulus = divisor.Modulus;
         if (modulus <= 1UL || (modulus & 1UL) == 0UL)
@@ -326,7 +326,7 @@ public class Pow2MontgomeryModBenchmarks
         return result.MontgomeryMultiply(1UL, modulus, nPrime);
     }
 
-    private static ulong Pow2MontgomeryModSlidingWindow(ulong exponent, in MersenneNumberDivisorByDivisorGpuTester.MontgomeryDivisorData divisor)
+    private static ulong Pow2MontgomeryModSlidingWindow(ulong exponent, in MontgomeryDivisorData divisor)
     {
         ulong modulus = divisor.Modulus;
         if (modulus <= 1UL || (modulus & 1UL) == 0UL)

--- a/PerfectNumbers.Core/CycleRemainderStepper.cs
+++ b/PerfectNumbers.Core/CycleRemainderStepper.cs
@@ -1,0 +1,84 @@
+using System.Numerics;
+
+namespace PerfectNumbers.Core;
+
+internal struct CycleRemainderStepper
+{
+    private readonly ulong _cycleLength;
+    private ulong _previousPrime;
+    private ulong _currentRemainder;
+    private bool _hasState;
+
+    public CycleRemainderStepper(ulong cycleLength)
+    {
+        _cycleLength = cycleLength;
+        _previousPrime = 0UL;
+        _currentRemainder = 0UL;
+        _hasState = false;
+    }
+
+    public bool HasCycle => _cycleLength != 0UL;
+
+    public void Reset()
+    {
+        _previousPrime = 0UL;
+        _currentRemainder = 0UL;
+        _hasState = false;
+    }
+
+    public void InitializeState(ulong previousPrime, ulong previousRemainder, bool hasState)
+    {
+        _previousPrime = previousPrime;
+        _currentRemainder = previousRemainder;
+        _hasState = hasState;
+    }
+
+    public ulong ComputeNext(ulong prime)
+    {
+        if (_cycleLength == 0UL)
+        {
+            _previousPrime = prime;
+            _currentRemainder = 0UL;
+            _hasState = true;
+            return 0UL;
+        }
+
+        if (!_hasState || prime <= _previousPrime)
+        {
+            _currentRemainder = prime % _cycleLength;
+            _hasState = true;
+        }
+        else
+        {
+            ulong delta = prime - _previousPrime;
+            if (ulong.MaxValue - _currentRemainder < delta)
+            {
+                UInt128 extended = (UInt128)_currentRemainder + delta;
+                _currentRemainder = (ulong)(extended % _cycleLength);
+            }
+            else
+            {
+                _currentRemainder += delta;
+
+                if (_currentRemainder >= _cycleLength)
+                {
+                    _currentRemainder -= _cycleLength;
+                    if (_currentRemainder >= _cycleLength)
+                    {
+                        _currentRemainder %= _cycleLength;
+                    }
+                }
+            }
+        }
+
+        _previousPrime = prime;
+        return _currentRemainder;
+    }
+
+    public void CaptureState(out ulong previousPrime, out ulong previousRemainder, out bool hasState)
+    {
+        previousPrime = _previousPrime;
+        previousRemainder = _currentRemainder;
+        hasState = _hasState;
+    }
+}

--- a/PerfectNumbers.Core/Gpu/MersenneNumberDivisorGpuTester.cs
+++ b/PerfectNumbers.Core/Gpu/MersenneNumberDivisorGpuTester.cs
@@ -13,25 +13,25 @@ public sealed class MersenneNumberDivisorGpuTester
 	private Action<Index1D, ulong, GpuUInt128, ArrayView<byte>> GetKernel(Accelerator accelerator) =>
 			_kernelCache.GetOrAdd(accelerator, acc => acc.LoadAutoGroupedStreamKernel<Index1D, ulong, GpuUInt128, ArrayView<byte>>(Kernel));
 
-	public static void BuildDivisorCandidates()
-	{
+        public static void BuildDivisorCandidates()
+        {
                 ulong[] snapshot = MersenneDivisorCycles.Shared.ExportSmallCyclesSnapshot();
-                (ulong divisor, ulong cycle)[] list = new (ulong divisor, ulong cycle)[snapshot.Length / 2];
+                (ulong divisor, uint cycle)[] list = new (ulong divisor, uint cycle)[snapshot.Length / 2];
                 ulong cycle;
-		int count = 0, i, snapshotLength = snapshot.Length;
-		for (i = 3; i < snapshotLength; i += 2)
-		{
-			cycle = snapshot[i];
-			if (cycle == 0U)
-			{
-				continue;
-			}
+                int count = 0, i, snapshotLength = snapshot.Length;
+                for (i = 3; i < snapshotLength; i += 2)
+                {
+                        cycle = snapshot[i];
+                        if (cycle == 0U)
+                        {
+                                continue;
+                        }
 
-			list[count++] = ((ulong)i, cycle);
-		}
+                        list[count++] = ((ulong)i, (uint)cycle);
+                }
 
                 _divisorCandidates = count == 0 ? [] : list[..count];
-	}
+        }
 
 	public bool IsDivisible(ulong exponent, UInt128 divisor)
 	{
@@ -52,7 +52,7 @@ public sealed class MersenneNumberDivisorGpuTester
 		return divisible;
 	}
 
-        private static (ulong divisor, ulong cycle)[]? _divisorCandidates = Array.Empty<(ulong divisor, ulong cycle)>();
+        private static (ulong divisor, uint cycle)[]? _divisorCandidates = Array.Empty<(ulong divisor, uint cycle)>();
 
 	public bool IsPrime(ulong p, UInt128 d, ulong divisorCyclesSearchLimit, out bool divisorsExhausted)
 	{
@@ -68,17 +68,17 @@ public sealed class MersenneNumberDivisorGpuTester
 			return true;
 		}
 
-		if (_divisorCandidates is { Length: > 0 } candidates)
-		{
-			int len = candidates.Length;
-                        ulong cycle;
-			for (int k = 0; k < len; k++)
-			{
-				(ulong dSmall, cycle) = candidates[k];
-				if (p % cycle != 0UL)
-				{
-					continue;
-				}
+                if (_divisorCandidates is { Length: > 0 } candidates)
+                {
+                        int len = candidates.Length;
+                        uint cycle;
+                        for (int k = 0; k < len; k++)
+                        {
+                                (ulong dSmall, cycle) = candidates[k];
+                                if (p % cycle != 0UL)
+                                {
+                                        continue;
+                                }
 
 				if (IsDivisible(p, dSmall))
 				{

--- a/PerfectNumbers.Core/MontgomeryDivisorData.cs
+++ b/PerfectNumbers.Core/MontgomeryDivisorData.cs
@@ -1,0 +1,148 @@
+using System.Collections.Concurrent;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace PerfectNumbers.Core;
+
+public readonly struct MontgomeryDivisorData(ulong modulus, ulong nPrime, ulong montgomeryOne, ulong montgomeryTwo)
+{
+    public ulong Modulus { get; } = modulus;
+
+    public ulong NPrime { get; } = nPrime;
+
+    public ulong MontgomeryOne { get; } = montgomeryOne;
+
+    public ulong MontgomeryTwo { get; } = montgomeryTwo;
+}
+
+internal static class MontgomeryDivisorDataCache
+{
+    private const ulong BaseBlockEnd = PerfectNumberConstants.MaxQForDivisorCycles;
+
+    private static readonly ConcurrentDictionary<ulong, CacheEntry> Cache = new();
+    private static readonly ConcurrentDictionary<int, ConcurrentDictionary<ulong, byte>> BlockMembership = new();
+
+    public static MontgomeryDivisorData Get(ulong modulus)
+    {
+        if (modulus <= 1UL || (modulus & 1UL) == 0UL)
+        {
+            return new MontgomeryDivisorData(modulus, 0UL, 0UL, 0UL);
+        }
+
+        int blockIndex = ComputeBlockIndex(modulus);
+        return GetManaged(modulus, blockIndex);
+    }
+
+    internal static void ReleaseBlock(DivisorCycleCache.CycleBlock block)
+    {
+        if (block.Index <= 0)
+        {
+            return;
+        }
+
+        if (BlockMembership.TryRemove(block.Index, out ConcurrentDictionary<ulong, byte>? members))
+        {
+            foreach (ulong modulus in members.Keys)
+            {
+                Cache.TryRemove(modulus, out _);
+            }
+        }
+    }
+
+    private static MontgomeryDivisorData GetManaged(ulong modulus, int blockIndex)
+    {
+        while (true)
+        {
+            if (Cache.TryGetValue(modulus, out CacheEntry entry))
+            {
+                if (entry.BlockIndex != blockIndex)
+                {
+                    if (blockIndex > 0 && entry.BlockIndex <= 0)
+                    {
+                        CacheEntry updated = new(entry.Data, blockIndex);
+                        if (Cache.TryUpdate(modulus, updated, entry))
+                        {
+                            RegisterBlockMembership(modulus, blockIndex);
+                            return entry.Data;
+                        }
+
+                        continue;
+                    }
+
+                    if (blockIndex > 0)
+                    {
+                        RegisterBlockMembership(modulus, blockIndex);
+                    }
+
+                    return entry.Data;
+                }
+                return entry.Data;
+            }
+
+            MontgomeryDivisorData created = Create(modulus);
+            if (Cache.TryAdd(modulus, new CacheEntry(created, blockIndex)))
+            {
+                RegisterBlockMembership(modulus, blockIndex);
+                return created;
+            }
+        }
+    }
+
+    private static void RegisterBlockMembership(ulong modulus, int blockIndex)
+    {
+        if (blockIndex <= 0)
+        {
+            return;
+        }
+
+        ConcurrentDictionary<ulong, byte> set = BlockMembership.GetOrAdd(blockIndex, static _ => new ConcurrentDictionary<ulong, byte>());
+        set.TryAdd(modulus, 0);
+    }
+
+    private static int ComputeBlockIndex(ulong modulus)
+    {
+        if (modulus <= BaseBlockEnd)
+        {
+            return 0;
+        }
+
+        return (int)((modulus - (BaseBlockEnd + 1UL)) / (ulong)PerfectNumberConstants.MaxQForDivisorCycles) + 1;
+    }
+
+    private static MontgomeryDivisorData Create(ulong modulus)
+    {
+        return new MontgomeryDivisorData(
+            modulus,
+            ComputeMontgomeryNPrime(modulus),
+            ComputeMontgomeryResidue(1UL, modulus),
+            ComputeMontgomeryResidue(2UL, modulus));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ulong ComputeMontgomeryResidue(ulong value, ulong modulus) => (ulong)((UInt128)value * (UInt128.One << 64) % modulus);
+
+    private static ulong ComputeMontgomeryNPrime(ulong modulus)
+    {
+        ulong inv = modulus;
+        inv *= unchecked(2UL - modulus * inv);
+        inv *= unchecked(2UL - modulus * inv);
+        inv *= unchecked(2UL - modulus * inv);
+        inv *= unchecked(2UL - modulus * inv);
+        inv *= unchecked(2UL - modulus * inv);
+        inv *= unchecked(2UL - modulus * inv);
+        return unchecked(0UL - inv);
+    }
+
+    private readonly struct CacheEntry
+    {
+        internal CacheEntry(MontgomeryDivisorData data, int blockIndex)
+        {
+            Data = data;
+            BlockIndex = blockIndex;
+        }
+
+        internal MontgomeryDivisorData Data { get; }
+
+        internal int BlockIndex { get; }
+    }
+}

--- a/PerfectNumbers.Core/ULongExtensions.cs
+++ b/PerfectNumbers.Core/ULongExtensions.cs
@@ -214,7 +214,7 @@ public static class ULongExtensions
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong Pow2MontgomeryMod(this ulong exponent, in MersenneNumberDivisorByDivisorGpuTester.MontgomeryDivisorData divisor)
+        public static ulong Pow2MontgomeryMod(this ulong exponent, in MontgomeryDivisorData divisor)
         {
                 ulong modulus = divisor.Modulus;
                 if (modulus <= 1UL || (modulus & 1UL) == 0UL)
@@ -247,7 +247,7 @@ public static class ULongExtensions
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong Pow2MontgomeryModWithCycle(this ulong exponent, ulong cycleLength, in MersenneNumberDivisorByDivisorGpuTester.MontgomeryDivisorData divisor)
+        public static ulong Pow2MontgomeryModWithCycle(this ulong exponent, ulong cycleLength, in MontgomeryDivisorData divisor)
         {
                 if (cycleLength == 0UL)
                 {
@@ -255,12 +255,18 @@ public static class ULongExtensions
                 }
 
                 ulong rotationCount = exponent % cycleLength;
-                if (rotationCount == 0UL)
+                return rotationCount.Pow2MontgomeryModFromCycleRemainder(divisor);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong Pow2MontgomeryModFromCycleRemainder(this ulong reducedExponent, in MontgomeryDivisorData divisor)
+        {
+                if (reducedExponent == 0UL)
                 {
                         return 1UL;
                 }
 
-                return rotationCount.Pow2MontgomeryMod(divisor);
+                return reducedExponent.Pow2MontgomeryMod(divisor);
         }
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Summary
- introduce a reusable cycle remainder stepper that increments residues without recomputing modulo values
- update the CPU and GPU by-divisor sessions to prefilter primes with the stepper and only enqueue candidates needing Montgomery work
- expose a Montgomery helper for reduced exponents so both paths reuse the cycle remainder during final checks

## Testing
- dotnet test PerfectNumbers.Core.Tests/PerfectNumbers.Core.Tests.csproj -c Release --filter "FullyQualifiedName~MersenneNumberDivisorGpuTesterTests"

------
https://chatgpt.com/codex/tasks/task_e_68d53afc19208325b564872aeeaec8f3