### PR TITLE
Accept heuristic prime order results

### DIFF
--- a/PerfectNumbers.Core/MersenneDivisorCycles.cs
+++ b/PerfectNumbers.Core/MersenneDivisorCycles.cs
@@ -807,7 +807,7 @@ public class MersenneDivisorCycles
                                 divisor,
                                 previousOrder: null,
                                 PrimeOrderCalculator.PrimeOrderSearchConfig.HeuristicDefault);
-                        if (orderResult.Status == PrimeOrderCalculator.PrimeOrderStatus.Found && orderResult.Order != 0UL)
+                        if (orderResult.Order != 0UL)
                         {
                                 return orderResult.Order;
                         }

--- a/PerfectNumbers.Core/PrimeOrderCalculator.cs
+++ b/PerfectNumbers.Core/PrimeOrderCalculator.cs
@@ -98,7 +98,7 @@ internal static class PrimeOrderCalculator
             return new PrimeOrderResult(PrimeOrderStatus.Found, order);
         }
 
-        return new PrimeOrderResult(PrimeOrderStatus.HeuristicUnresolved, 0UL);
+        return FinishStrictly(prime, config.Mode);
     }
 
     private static PrimeOrderResult FinishStrictly(ulong prime, PrimeOrderMode mode)


### PR DESCRIPTION
## Summary
- fall back to the strict prime order calculation when the heuristic search cannot resolve a result
- treat any non-zero prime order result as valid when deriving divisor cycle lengths

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e03d1252a483258ecbc4daeb51b015