### PR TITLE
Fix Montgomery odd power table indexer compilation errors

### DIFF
--- a/PerfectNumbers.Core/ULongExtensions.cs
+++ b/PerfectNumbers.Core/ULongExtensions.cs
@@ -11,10 +11,810 @@ public static class ULongExtensions
     private const ulong Pow2WindowFallbackThreshold = 32UL;
     private const int Pow2WindowOddPowerCount = 1 << (Pow2WindowSize - 1);
 
-    [InlineArray(Pow2WindowOddPowerCount)]
     private struct Pow2OddPowerTable
     {
-        private ulong _element0;
+        public ulong Element0;
+        public ulong Element1;
+        public ulong Element2;
+        public ulong Element3;
+        public ulong Element4;
+        public ulong Element5;
+        public ulong Element6;
+        public ulong Element7;
+        public ulong Element8;
+        public ulong Element9;
+        public ulong Element10;
+        public ulong Element11;
+        public ulong Element12;
+        public ulong Element13;
+        public ulong Element14;
+        public ulong Element15;
+        public ulong Element16;
+        public ulong Element17;
+        public ulong Element18;
+        public ulong Element19;
+        public ulong Element20;
+        public ulong Element21;
+        public ulong Element22;
+        public ulong Element23;
+        public ulong Element24;
+        public ulong Element25;
+        public ulong Element26;
+        public ulong Element27;
+        public ulong Element28;
+        public ulong Element29;
+        public ulong Element30;
+        public ulong Element31;
+        public ulong Element32;
+        public ulong Element33;
+        public ulong Element34;
+        public ulong Element35;
+        public ulong Element36;
+        public ulong Element37;
+        public ulong Element38;
+        public ulong Element39;
+        public ulong Element40;
+        public ulong Element41;
+        public ulong Element42;
+        public ulong Element43;
+        public ulong Element44;
+        public ulong Element45;
+        public ulong Element46;
+        public ulong Element47;
+        public ulong Element48;
+        public ulong Element49;
+        public ulong Element50;
+        public ulong Element51;
+        public ulong Element52;
+        public ulong Element53;
+        public ulong Element54;
+        public ulong Element55;
+        public ulong Element56;
+        public ulong Element57;
+        public ulong Element58;
+        public ulong Element59;
+        public ulong Element60;
+        public ulong Element61;
+        public ulong Element62;
+        public ulong Element63;
+        public ulong Element64;
+        public ulong Element65;
+        public ulong Element66;
+        public ulong Element67;
+        public ulong Element68;
+        public ulong Element69;
+        public ulong Element70;
+        public ulong Element71;
+        public ulong Element72;
+        public ulong Element73;
+        public ulong Element74;
+        public ulong Element75;
+        public ulong Element76;
+        public ulong Element77;
+        public ulong Element78;
+        public ulong Element79;
+        public ulong Element80;
+        public ulong Element81;
+        public ulong Element82;
+        public ulong Element83;
+        public ulong Element84;
+        public ulong Element85;
+        public ulong Element86;
+        public ulong Element87;
+        public ulong Element88;
+        public ulong Element89;
+        public ulong Element90;
+        public ulong Element91;
+        public ulong Element92;
+        public ulong Element93;
+        public ulong Element94;
+        public ulong Element95;
+        public ulong Element96;
+        public ulong Element97;
+        public ulong Element98;
+        public ulong Element99;
+        public ulong Element100;
+        public ulong Element101;
+        public ulong Element102;
+        public ulong Element103;
+        public ulong Element104;
+        public ulong Element105;
+        public ulong Element106;
+        public ulong Element107;
+        public ulong Element108;
+        public ulong Element109;
+        public ulong Element110;
+        public ulong Element111;
+        public ulong Element112;
+        public ulong Element113;
+        public ulong Element114;
+        public ulong Element115;
+        public ulong Element116;
+        public ulong Element117;
+        public ulong Element118;
+        public ulong Element119;
+        public ulong Element120;
+        public ulong Element121;
+        public ulong Element122;
+        public ulong Element123;
+        public ulong Element124;
+        public ulong Element125;
+        public ulong Element126;
+        public ulong Element127;
+
+        public ulong this[int index]
+        {
+            readonly get
+            {
+                return GetElement(index);
+            }
+
+            set
+            {
+                SetElement(index, value);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private readonly ulong GetElement(int index)
+        {
+            switch (index)
+            {
+            case 0:
+                return Element0;
+            case 1:
+                return Element1;
+            case 2:
+                return Element2;
+            case 3:
+                return Element3;
+            case 4:
+                return Element4;
+            case 5:
+                return Element5;
+            case 6:
+                return Element6;
+            case 7:
+                return Element7;
+            case 8:
+                return Element8;
+            case 9:
+                return Element9;
+            case 10:
+                return Element10;
+            case 11:
+                return Element11;
+            case 12:
+                return Element12;
+            case 13:
+                return Element13;
+            case 14:
+                return Element14;
+            case 15:
+                return Element15;
+            case 16:
+                return Element16;
+            case 17:
+                return Element17;
+            case 18:
+                return Element18;
+            case 19:
+                return Element19;
+            case 20:
+                return Element20;
+            case 21:
+                return Element21;
+            case 22:
+                return Element22;
+            case 23:
+                return Element23;
+            case 24:
+                return Element24;
+            case 25:
+                return Element25;
+            case 26:
+                return Element26;
+            case 27:
+                return Element27;
+            case 28:
+                return Element28;
+            case 29:
+                return Element29;
+            case 30:
+                return Element30;
+            case 31:
+                return Element31;
+            case 32:
+                return Element32;
+            case 33:
+                return Element33;
+            case 34:
+                return Element34;
+            case 35:
+                return Element35;
+            case 36:
+                return Element36;
+            case 37:
+                return Element37;
+            case 38:
+                return Element38;
+            case 39:
+                return Element39;
+            case 40:
+                return Element40;
+            case 41:
+                return Element41;
+            case 42:
+                return Element42;
+            case 43:
+                return Element43;
+            case 44:
+                return Element44;
+            case 45:
+                return Element45;
+            case 46:
+                return Element46;
+            case 47:
+                return Element47;
+            case 48:
+                return Element48;
+            case 49:
+                return Element49;
+            case 50:
+                return Element50;
+            case 51:
+                return Element51;
+            case 52:
+                return Element52;
+            case 53:
+                return Element53;
+            case 54:
+                return Element54;
+            case 55:
+                return Element55;
+            case 56:
+                return Element56;
+            case 57:
+                return Element57;
+            case 58:
+                return Element58;
+            case 59:
+                return Element59;
+            case 60:
+                return Element60;
+            case 61:
+                return Element61;
+            case 62:
+                return Element62;
+            case 63:
+                return Element63;
+            case 64:
+                return Element64;
+            case 65:
+                return Element65;
+            case 66:
+                return Element66;
+            case 67:
+                return Element67;
+            case 68:
+                return Element68;
+            case 69:
+                return Element69;
+            case 70:
+                return Element70;
+            case 71:
+                return Element71;
+            case 72:
+                return Element72;
+            case 73:
+                return Element73;
+            case 74:
+                return Element74;
+            case 75:
+                return Element75;
+            case 76:
+                return Element76;
+            case 77:
+                return Element77;
+            case 78:
+                return Element78;
+            case 79:
+                return Element79;
+            case 80:
+                return Element80;
+            case 81:
+                return Element81;
+            case 82:
+                return Element82;
+            case 83:
+                return Element83;
+            case 84:
+                return Element84;
+            case 85:
+                return Element85;
+            case 86:
+                return Element86;
+            case 87:
+                return Element87;
+            case 88:
+                return Element88;
+            case 89:
+                return Element89;
+            case 90:
+                return Element90;
+            case 91:
+                return Element91;
+            case 92:
+                return Element92;
+            case 93:
+                return Element93;
+            case 94:
+                return Element94;
+            case 95:
+                return Element95;
+            case 96:
+                return Element96;
+            case 97:
+                return Element97;
+            case 98:
+                return Element98;
+            case 99:
+                return Element99;
+            case 100:
+                return Element100;
+            case 101:
+                return Element101;
+            case 102:
+                return Element102;
+            case 103:
+                return Element103;
+            case 104:
+                return Element104;
+            case 105:
+                return Element105;
+            case 106:
+                return Element106;
+            case 107:
+                return Element107;
+            case 108:
+                return Element108;
+            case 109:
+                return Element109;
+            case 110:
+                return Element110;
+            case 111:
+                return Element111;
+            case 112:
+                return Element112;
+            case 113:
+                return Element113;
+            case 114:
+                return Element114;
+            case 115:
+                return Element115;
+            case 116:
+                return Element116;
+            case 117:
+                return Element117;
+            case 118:
+                return Element118;
+            case 119:
+                return Element119;
+            case 120:
+                return Element120;
+            case 121:
+                return Element121;
+            case 122:
+                return Element122;
+            case 123:
+                return Element123;
+            case 124:
+                return Element124;
+            case 125:
+                return Element125;
+            case 126:
+                return Element126;
+            case 127:
+                return Element127;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(index), index, "Pow2OddPowerTable index must be between 0 and 127.");
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void SetElement(int index, ulong value)
+        {
+            switch (index)
+            {
+            case 0:
+                Element0 = value;
+                return;
+            case 1:
+                Element1 = value;
+                return;
+            case 2:
+                Element2 = value;
+                return;
+            case 3:
+                Element3 = value;
+                return;
+            case 4:
+                Element4 = value;
+                return;
+            case 5:
+                Element5 = value;
+                return;
+            case 6:
+                Element6 = value;
+                return;
+            case 7:
+                Element7 = value;
+                return;
+            case 8:
+                Element8 = value;
+                return;
+            case 9:
+                Element9 = value;
+                return;
+            case 10:
+                Element10 = value;
+                return;
+            case 11:
+                Element11 = value;
+                return;
+            case 12:
+                Element12 = value;
+                return;
+            case 13:
+                Element13 = value;
+                return;
+            case 14:
+                Element14 = value;
+                return;
+            case 15:
+                Element15 = value;
+                return;
+            case 16:
+                Element16 = value;
+                return;
+            case 17:
+                Element17 = value;
+                return;
+            case 18:
+                Element18 = value;
+                return;
+            case 19:
+                Element19 = value;
+                return;
+            case 20:
+                Element20 = value;
+                return;
+            case 21:
+                Element21 = value;
+                return;
+            case 22:
+                Element22 = value;
+                return;
+            case 23:
+                Element23 = value;
+                return;
+            case 24:
+                Element24 = value;
+                return;
+            case 25:
+                Element25 = value;
+                return;
+            case 26:
+                Element26 = value;
+                return;
+            case 27:
+                Element27 = value;
+                return;
+            case 28:
+                Element28 = value;
+                return;
+            case 29:
+                Element29 = value;
+                return;
+            case 30:
+                Element30 = value;
+                return;
+            case 31:
+                Element31 = value;
+                return;
+            case 32:
+                Element32 = value;
+                return;
+            case 33:
+                Element33 = value;
+                return;
+            case 34:
+                Element34 = value;
+                return;
+            case 35:
+                Element35 = value;
+                return;
+            case 36:
+                Element36 = value;
+                return;
+            case 37:
+                Element37 = value;
+                return;
+            case 38:
+                Element38 = value;
+                return;
+            case 39:
+                Element39 = value;
+                return;
+            case 40:
+                Element40 = value;
+                return;
+            case 41:
+                Element41 = value;
+                return;
+            case 42:
+                Element42 = value;
+                return;
+            case 43:
+                Element43 = value;
+                return;
+            case 44:
+                Element44 = value;
+                return;
+            case 45:
+                Element45 = value;
+                return;
+            case 46:
+                Element46 = value;
+                return;
+            case 47:
+                Element47 = value;
+                return;
+            case 48:
+                Element48 = value;
+                return;
+            case 49:
+                Element49 = value;
+                return;
+            case 50:
+                Element50 = value;
+                return;
+            case 51:
+                Element51 = value;
+                return;
+            case 52:
+                Element52 = value;
+                return;
+            case 53:
+                Element53 = value;
+                return;
+            case 54:
+                Element54 = value;
+                return;
+            case 55:
+                Element55 = value;
+                return;
+            case 56:
+                Element56 = value;
+                return;
+            case 57:
+                Element57 = value;
+                return;
+            case 58:
+                Element58 = value;
+                return;
+            case 59:
+                Element59 = value;
+                return;
+            case 60:
+                Element60 = value;
+                return;
+            case 61:
+                Element61 = value;
+                return;
+            case 62:
+                Element62 = value;
+                return;
+            case 63:
+                Element63 = value;
+                return;
+            case 64:
+                Element64 = value;
+                return;
+            case 65:
+                Element65 = value;
+                return;
+            case 66:
+                Element66 = value;
+                return;
+            case 67:
+                Element67 = value;
+                return;
+            case 68:
+                Element68 = value;
+                return;
+            case 69:
+                Element69 = value;
+                return;
+            case 70:
+                Element70 = value;
+                return;
+            case 71:
+                Element71 = value;
+                return;
+            case 72:
+                Element72 = value;
+                return;
+            case 73:
+                Element73 = value;
+                return;
+            case 74:
+                Element74 = value;
+                return;
+            case 75:
+                Element75 = value;
+                return;
+            case 76:
+                Element76 = value;
+                return;
+            case 77:
+                Element77 = value;
+                return;
+            case 78:
+                Element78 = value;
+                return;
+            case 79:
+                Element79 = value;
+                return;
+            case 80:
+                Element80 = value;
+                return;
+            case 81:
+                Element81 = value;
+                return;
+            case 82:
+                Element82 = value;
+                return;
+            case 83:
+                Element83 = value;
+                return;
+            case 84:
+                Element84 = value;
+                return;
+            case 85:
+                Element85 = value;
+                return;
+            case 86:
+                Element86 = value;
+                return;
+            case 87:
+                Element87 = value;
+                return;
+            case 88:
+                Element88 = value;
+                return;
+            case 89:
+                Element89 = value;
+                return;
+            case 90:
+                Element90 = value;
+                return;
+            case 91:
+                Element91 = value;
+                return;
+            case 92:
+                Element92 = value;
+                return;
+            case 93:
+                Element93 = value;
+                return;
+            case 94:
+                Element94 = value;
+                return;
+            case 95:
+                Element95 = value;
+                return;
+            case 96:
+                Element96 = value;
+                return;
+            case 97:
+                Element97 = value;
+                return;
+            case 98:
+                Element98 = value;
+                return;
+            case 99:
+                Element99 = value;
+                return;
+            case 100:
+                Element100 = value;
+                return;
+            case 101:
+                Element101 = value;
+                return;
+            case 102:
+                Element102 = value;
+                return;
+            case 103:
+                Element103 = value;
+                return;
+            case 104:
+                Element104 = value;
+                return;
+            case 105:
+                Element105 = value;
+                return;
+            case 106:
+                Element106 = value;
+                return;
+            case 107:
+                Element107 = value;
+                return;
+            case 108:
+                Element108 = value;
+                return;
+            case 109:
+                Element109 = value;
+                return;
+            case 110:
+                Element110 = value;
+                return;
+            case 111:
+                Element111 = value;
+                return;
+            case 112:
+                Element112 = value;
+                return;
+            case 113:
+                Element113 = value;
+                return;
+            case 114:
+                Element114 = value;
+                return;
+            case 115:
+                Element115 = value;
+                return;
+            case 116:
+                Element116 = value;
+                return;
+            case 117:
+                Element117 = value;
+                return;
+            case 118:
+                Element118 = value;
+                return;
+            case 119:
+                Element119 = value;
+                return;
+            case 120:
+                Element120 = value;
+                return;
+            case 121:
+                Element121 = value;
+                return;
+            case 122:
+                Element122 = value;
+                return;
+            case 123:
+                Element123 = value;
+                return;
+            case 124:
+                Element124 = value;
+                return;
+            case 125:
+                Element125 = value;
+                return;
+            case 126:
+                Element126 = value;
+                return;
+            case 127:
+                Element127 = value;
+                return;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(index), index, "Pow2OddPowerTable index must be between 0 and 127.");
+            }
+        }
+
     }
 
     public static ulong CalculateOrder(this ulong q)


### PR DESCRIPTION
## Summary
- replace the ref-returning Montgomery odd power table indexer with value-based get/set accessors so the struct compiles against main

## Testing
- dotnet build EvenPerfectScanner.sln

------
https://chatgpt.com/codex/tasks/task_e_68e1f68daa8c8325b06297365127abc2